### PR TITLE
Changed http to https where possible

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -17,8 +17,8 @@ This document explains the conventions used within this guide.
 1. Use **[JSON-LD](https://json-ld.org/)** in our guidance documents for simplicity and terseness as compared to *[Microdata](https://www.w3.org/TR/microdata/)* and *[RDFa](https://rdfa.info/)*.
 2. Documents should start with:
   1. An named anchor of 'top': ```<a id="top"></a>```
-  2. A breadcrumb trail respective to the level in the guide:  
-  
+  2. A breadcrumb trail respective to the level in the guide:
+
      <pre>[Home](/README.md) | [Some directory](/guides/<dir-name>) | This Location in the guide</pre>
 
 2. Documents should describe *how* and *why* for each class and property being recommended.
@@ -51,7 +51,7 @@ This document explains the conventions used within this guide.
   6. Next, insert the image with: ```<img src="/assets/<path-to-image-file e.g. schemaorg-datatypes.png>">```
   7. Optionally, add an italicized description with: ```<em>optional description goes here...</em>```
 
-Figure example: 
+Figure example:
 ```
   <a id="figure-1"></a>
   <p align="center">
@@ -61,9 +61,9 @@ Figure example:
   </p>
 ```
 
-6. **Namespace for `schema.org`.** Use `https://schema.org/`. 
+6. **Namespace for `schema.org`.** Use `https://schema.org/`.
 
-  Consistent representation of namespaces simplifies programmatic processing of markup. For example, even though conceptually it is clear the terms `http://schema.org/Dataset` and `https://schema.org/Dataset` (note the protocol difference) are referring to [https://schema.org/Dataset](https://schema.org/Dataset), these are programmatically treated as different entities. The [schema.org guidelines](https://schema.org/docs/faq.html#19) are somewhat ambivalent on the topic, with perhaps emphasis on `"https"`. 
+  Consistent representation of namespaces simplifies programmatic processing of markup. For example, even though conceptually it is clear the terms `http://schema.org/Dataset` and `https://schema.org/Dataset` (note the protocol difference) are referring to [https://schema.org/Dataset](https://schema.org/Dataset), these are programmatically treated as different entities. The [schema.org guidelines](https://schema.org/docs/faq.html#19) are somewhat ambivalent on the topic, with perhaps emphasis on `"https"`.
 
   The trailing slash (`/`) is also important. Without it, common RDF processing libraries such as [rdflib](https://rdflib.readthedocs.io/en/stable/) will construct a term like `"https://schema.orgDataset"`. For example:
 
@@ -101,29 +101,29 @@ Given a version number MAJOR.MINOR.PATCH, increment the:
 Schema.org allows can be described using Microdata, RDFa, and JSON-LD. In this guide, we will use JSON-LD because:
 
 1. **Simplicity** - JSON-LD is the *most succinct* of the formats for communicating our *intent* with the recommendations.
-2. **Tersenees** - the JSON-LD ```[@context](https://json-ld.org/spec/latest/json-ld/#the-context)``` property allows publishers to express the data type of a specific properties of the data graph. 
+2. **Tersenees** - the JSON-LD ```[@context](https://json-ld.org/spec/latest/json-ld/#the-context)``` property allows publishers to express the data type of a specific properties of the data graph.
 
-*NOTE: Our intent is not to override [http://schema.org/](http://schema.org/) classes and properties, but to provide flexibility to our examples and recommendations when using external vocabularies.*
+*NOTE: Our intent is not to override [https://schema.org/](https://schema.org/) classes and properties, but to provide flexibility to our examples and recommendations when using external vocabularies.*
 
 
 <a id="external-vocab-typing"></a>
 ## Typing to External Vocabularies ##
 
-Schema.org provides a property called [schema:additionalType](http://schema.org/additionalType) for typing resources in a data graph to external vocabularies. Here is the RDF that defines this property:
+Schema.org provides a property called [schema:additionalType](https://schema.org/additionalType) for typing resources in a data graph to external vocabularies. Here is the RDF that defines this property:
 
 ```
 <rdf:RDF
-  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-  xmlns:schema="http://schema.org/"
+  xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="https://www.w3.org/2000/01/rdf-schema#"
+  xmlns:schema="https://schema.org/"
 >
-    <rdf:Property rdf:about="http://schema.org/additionalType">
-        <schema:rangeIncludes rdf:resource="http://schema.org/URL"/>
+    <rdf:Property rdf:about="https://schema.org/additionalType">
+        <schema:rangeIncludes rdf:resource="https://schema.org/URL"/>
         <rdfs:comment>An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</rdfs:comment>
         <schema:sameAs rdf:resource="https://schema.org/additionalType"/>
-        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <rdfs:subPropertyOf rdf:resource="https://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
         <rdfs:label>additionalType</rdfs:label>
-        <schema:domainIncludes rdf:resource="http://schema.org/Thing"/>
+        <schema:domainIncludes rdf:resource="https://schema.org/Thing"/>
     </rdf:Property>
 </rdf:RDF>
 ```
@@ -132,12 +132,12 @@ Schema.org provides a property called [schema:additionalType](http://schema.org/
 
 ```
 ...
-<schema:rangeIncludes rdf:resource="http://schema.org/URL"/>
-<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+<schema:rangeIncludes rdf:resource="https://schema.org/URL"/>
+<rdfs:subPropertyOf rdf:resource="https://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
 ...
 ```
 
 Publishers who have a ```@context``` with prefixes for external vocabularies cannot use the prefixed URL in schema:additionalType
 
 ...add JSON-LD Playground example showing that additionalType does not expand the prefix nor generate an rdf:type triple...
- 
+

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -14,7 +14,7 @@ This document explains the conventions used within this guide.
 <a id="syntax"></a>
 ## Syntax ##
 
-1. Use **[JSON-LD](https://json-ld.org/)** in our guidance documents for simplicity and terseness as compared to *[Microdata](https://www.w3.org/TR/microdata/)* and *[RDFa](https://rdfa.info/)*.
+1. Use **[JSON-LD](https://json-ld.org/)** in our guidance documents for simplicity and terseness as compared to *[Microdata](http://www.w3.org/TR/microdata/)* and *[RDFa](https://rdfa.info/)*.
 2. Documents should start with:
   1. An named anchor of 'top': ```<a id="top"></a>```
   2. A breadcrumb trail respective to the level in the guide:
@@ -113,15 +113,15 @@ Schema.org provides a property called [schema:additionalType](https://schema.org
 
 ```
 <rdf:RDF
-  xmlns:rdf="https://www.w3.org/1999/02/22-rdf-syntax-ns#"
-  xmlns:rdfs="https://www.w3.org/2000/01/rdf-schema#"
+  xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
   xmlns:schema="https://schema.org/"
 >
     <rdf:Property rdf:about="https://schema.org/additionalType">
         <schema:rangeIncludes rdf:resource="https://schema.org/URL"/>
         <rdfs:comment>An additional type for the item, typically used for adding more specific types from external vocabularies in microdata syntax. This is a relationship between something and a class that the thing is in. In RDFa syntax, it is better to use the native RDFa syntax - the 'typeof' attribute - for multiple types. Schema.org tools may have only weaker understanding of extra types, in particular those defined externally.</rdfs:comment>
         <schema:sameAs rdf:resource="https://schema.org/additionalType"/>
-        <rdfs:subPropertyOf rdf:resource="https://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+        <rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
         <rdfs:label>additionalType</rdfs:label>
         <schema:domainIncludes rdf:resource="https://schema.org/Thing"/>
     </rdf:Property>
@@ -133,7 +133,7 @@ Schema.org provides a property called [schema:additionalType](https://schema.org
 ```
 ...
 <schema:rangeIncludes rdf:resource="https://schema.org/URL"/>
-<rdfs:subPropertyOf rdf:resource="https://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+<rdfs:subPropertyOf rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
 ...
 ```
 

--- a/examples/data-repository/full.jsonld
+++ b/examples/data-repository/full.jsonld
@@ -1,17 +1,17 @@
 {
     "@context": {
-        "@vocab": "http://schema.org/",
-        "datacite": "http://purl.org/spar/datacite/"
+        "@vocab": "https://schema.org/",
+        "datacite": "https://purl.org/spar/datacite/"
     },
     "@type": ["Service", "ResearchProject", "WebSite"],
-    "@id": "http://lod.bco-dmo.org/id/affiliation/191",
+    "@id": "https://lod.bco-dmo.org/id/affiliation/191",
     "legalName": "Biological and Chemical Data Management Office",
     "name": "BCO-DMO",
     "url": "https://www.bco-dmo.org",
     "category": ["Biological Oceanography", "Chemical Oceanography"],
     "description": "The BCO-DMO resource catalog offers free and open access to publicly funded research products whose field of study are biological and chemical oceanography.",
     "sameAs": [
-        "http://www.re3data.org/repository/r3d100000012",
+        "https://www.re3data.org/repository/r3d100000012",
         "https://twitter.com/BCODMO",
         "https://www.linkedin.com/company/6378439/"
     ],
@@ -44,7 +44,7 @@
       "contactType": "customer support"
     },
     "provider": {
-        "@id": "http://lod.bco-dmo.org/id/affiliation/191"
+        "@id": "https://lod.bco-dmo.org/id/affiliation/191"
     },
     "funder": {
       "@type": "FundingAgency",
@@ -61,10 +61,10 @@
       },
       "parentOrganization": {
         "@type": "FundingAgency",
-        "@id": "http://dx.doi.org/10.13039/100000085",
+        "@id": "https://dx.doi.org/10.13039/100000085",
         "legalName": "Directorate for Geosciences",
         "alternateName": "NSF-GEO",
-        "url": "http://www.nsf.gov",
+        "url": "https://www.nsf.gov",
         "identifier": {
           "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
           "datacite:usesIdentifierScheme": { "@id": "datacite:doi" },
@@ -74,10 +74,10 @@
          },
         "parentOrganization": {
           "@type": "FundingAgency",
-          "@id": "http://dx.doi.org/10.13039/100000001",
+          "@id": "https://dx.doi.org/10.13039/100000001",
           "legalName": "National Science Foundation",
           "alternateName": "NSF",
-          "url": "http://www.nsf.gov",
+          "url": "https://www.nsf.gov",
           "identifier": {
             "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
             "datacite:usesIdentifierScheme": { "@id": "datacite:doi" },
@@ -90,9 +90,9 @@
     },
     "parentOrganization": {
       "@type": "Organization",
-      "@id": "http://www.whoi.edu",
+      "@id": "https://www.whoi.edu",
       "name": "Woods Hole Oceanographic Institution",
-      "url": "http://www.whoi.edu",
+      "url": "https://www.whoi.edu",
       "address": {
         "@type": "PostalAddress",
         "streetAddress": "266 Woods Hole Road",
@@ -129,10 +129,10 @@
         },
         {
             "@type": "ServiceChannel",
-            "serviceUrl": "http://lod.bco-dmo.org/sparql",
+            "serviceUrl": "https://lod.bco-dmo.org/sparql",
             "providesService": {
                 "@type": "Service",
-                "@id": "http://lod.bco-dmo.org/sparql",
+                "@id": "https://lod.bco-dmo.org/sparql",
                 "name": "SPARQL Endpoint",
                 "description": "Investigate BCO-DMO structured data for discovering datasets, people, projects, funding awards, deployments, instrumentation and measurements, their properties and relationships to internal and external resources",
                 "potentialAction": {
@@ -140,7 +140,7 @@
                     "target": {
                         "@type": "EntryPoint",
                         "contentType": ["application/sparql-results+json", "application/sparql-results+xml"],
-                        "urlTemplate": "http://lod.bco-dmo.org/sparql?default-graph-uri={graph_iri}&query={sparql_query}&output={format}&timeout={timeout_sec}&debug={on_or_off}",
+                        "urlTemplate": "https://lod.bco-dmo.org/sparql?default-graph-uri={graph_iri}&query={sparql_query}&output={format}&timeout={timeout_sec}&debug={on_or_off}",
                         "description": "Search BCO-DMO RDF through its SPARQL Endpoint",
                         "httpMethod": ["GET", "POST"]
                     },

--- a/examples/data-repository/minimal.jsonld
+++ b/examples/data-repository/minimal.jsonld
@@ -1,6 +1,6 @@
 {
     "@context": {
-        "@vocab": "http://schema.org/"
+        "@vocab": "https://schema.org/"
     },
     "@type": ["Service", "ResearchProject"],
     "legalName": "Example Data Repository",

--- a/examples/dataset/full.jsonld
+++ b/examples/dataset/full.jsonld
@@ -1,9 +1,9 @@
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
-  "@id": "http://lod.example-data-repository.org/id/dataset/3300",
+  "@id": "https://lod.example-data-repository.org/id/dataset/3300",
   "identifier": {
       "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
       "datacite:usesIdentifierScheme": { "@id": "datacite:doi" },
@@ -24,13 +24,13 @@
   "creator": [
     {
       "@type": "Person",
-      "@id": "http://lod.example-data-repository.org/id/person/51159",
+      "@id": "https://lod.example-data-repository.org/id/person/51159",
       "name": "Dr Langdon Quetin",
       "url": "https://www.example-data-repository.org/person/51159"
     },
     {
       "@type": "Person",
-      "@id": "http://lod.example-data-repository.org/id/person/51160",
+      "@id": "https://lod.example-data-repository.org/id/person/51160",
       "name": "Dr Robin Ross",
       "url": "https://www.example-data-repository.org/person/51160"
     }
@@ -48,19 +48,19 @@
     },
     "additionalProperty": {
       "@type": "PropertyValue",
-      "additionalType": "http://www.wikidata.org/entity/Q4018860",
+      "additionalType": "https://www.wikidata.org/entity/Q4018860",
       "name": "WKT",
       "value": "POLYGON ((-75.8183 -68.4817, -68.5033 -68.4817, -68.5033 -65.08, -75.8183 -65.08, -75.8183 -68.4817))",
       "valueReference": [
         {
           "@type": "PropertyValue",
           "name": "datatype",
-          "additionalType": "http://www.wikidata.org/entity/Q31385480",
+          "additionalType": "https://www.wikidata.org/entity/Q31385480",
           "value": "http://www.opengis.net/ont/geosparql#wktLiteral"
         },
         {
           "@type": "PropertyValue",
-          "additionalType": "http://www.wikidata.org/entity/Q161779",
+          "additionalType": "https://www.wikidata.org/entity/Q161779",
           "name": "SRS",
           "alternateName": "Spatial Reference System",
           "value": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
@@ -92,7 +92,7 @@
   "variableMeasured": [
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20860",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20860",
       "name": "cruiseid",
       "description": "cruise identification",
       "url": "https://www.example-data-repository.org/dataset-parameter/20860",
@@ -100,7 +100,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20861",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20861",
       "name": "year",
       "description": "year of experiment",
       "url": "https://www.example-data-repository.org/dataset-parameter/20861",
@@ -108,7 +108,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20862",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20862",
       "name": "sample_id",
       "description": "sample identification: WBC=whole body clearance expt.; WBF=whole body fluorescence on collection",
       "url": "https://www.example-data-repository.org/dataset-parameter/20862",
@@ -116,7 +116,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20863",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20863",
       "name": "time_sample",
       "description": "time of sampling for pigment content after collection; decline of pigment content with time was used to calculate time to clear the gut of pigment.",
       "url": "https://www.example-data-repository.org/dataset-parameter/20863",
@@ -124,7 +124,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20864",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20864",
       "name": "pigment_content",
       "description": "pigment content",
       "url": "https://www.example-data-repository.org/dataset-parameter/20864",
@@ -132,14 +132,14 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20865",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20865",
       "name": "stage_id",
       "description": "stage development index of larvae in sample (furcilia = F1-6 = 1-6,  juvenile = J=7)",
       "url": "https://www.example-data-repository.org/dataset-parameter/20865"
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20866",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20866",
       "name": "wet_weight",
       "description": "average wet weight/larvae in sample",
       "url": "https://www.example-data-repository.org/dataset-parameter/20866",
@@ -147,7 +147,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20874",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20874",
       "name": "lat",
       "description": "latitude, in decimal degrees, North is positive, negative denotes South",
       "url": "https://www.example-data-repository.org/dataset-parameter/20874",
@@ -155,7 +155,7 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20875",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20875",
       "name": "lon",
       "description": "longitude, in decimal degrees, East is positive, negative denotes West",
       "url": "https://www.example-data-repository.org/dataset-parameter/20875",
@@ -163,28 +163,28 @@
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20876",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20876",
       "name": "day_local",
       "description": "day of month, local time",
       "url": "https://www.example-data-repository.org/dataset-parameter/20876"
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20877",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20877",
       "name": "month_local",
       "description": "month, local time\n",
       "url": "https://www.example-data-repository.org/dataset-parameter/20877"
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20878",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20878",
       "name": "time_local",
       "description": "time of day, local time, using 2400 clock format",
       "url": "https://www.example-data-repository.org/dataset-parameter/20878"
     },
     {
       "@type": "PropertyValue",
-      "@id": "http://lod.example-data-repository.org/id/dataset-parameter/20879",
+      "@id": "https://lod.example-data-repository.org/id/dataset-parameter/20879",
       "name": "yrday_local",
       "description": "local day and decimal time, as 326.5 for the 326th day of the year, or November 22 at 1200 hours (noon)",
       "url": "https://www.example-data-repository.org/dataset-parameter/20879"
@@ -198,14 +198,14 @@
       "legalName": "NSF Antarctic Sciences",
       "makesOffer": [
         {
-          "@id": "http://lod.example-data-repository.org/id/award/55102",
+          "@id": "https://lod.example-data-repository.org/id/award/55102",
           "@type": "Offer",
           "name": "ANT-9909933",
           "url": "https://www.example-data-repository.org/award/55102",
-          "sameAs": "http://www.nsf.gov/awardsearch/showAward.do?AwardNumber=9909933",
+          "sameAs": "https://www.nsf.gov/awardsearch/showAward.do?AwardNumber=9909933",
           "offeredBy": {
             "@type": "Person",
-            "@id": "http://lod.example-data-repository.org/id/person/51469",
+            "@id": "https://lod.example-data-repository.org/id/person/51469",
             "name": "Dr Roberta Marinelli",
             "url": "https://www.example-data-repository.org/person/51469"
           }

--- a/examples/dataset/minimal.jsonld
+++ b/examples/dataset/minimal.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",

--- a/guides/DataRepository.md
+++ b/guides/DataRepository.md
@@ -15,12 +15,12 @@
 
 [![Repository  - Overview](/assets/diagrams/repository/repository-overview.svg "Repository - Overview")](#)
 
-In schema.org, we model a repository as both an [schema:ResearchProject](https://schema.org/ResearchProject), a sub-class of an Organization, and a [schema:Service](https://schema.org/Service). This double-typing gives us the most flexibility in describing the characteristics of the organization providing the service and the services offered by the organization. 
+In schema.org, we model a repository as both an [schema:ResearchProject](https://schema.org/ResearchProject), a sub-class of an Organization, and a [schema:Service](https://schema.org/Service). This double-typing gives us the most flexibility in describing the characteristics of the organization providing the service and the services offered by the organization.
 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   <strong>"@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -45,7 +45,7 @@ The other fields you can use to describe the Organziation and the Service are:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -53,7 +53,7 @@ The other fields you can use to describe the Organziation and the Service are:
   <strong>"url": "https://www.sample-data-repository.org",
   "description": "The Sample Data Repository Service provides access to data from an imaginary domain accessible from this website.",
   "sameAs": [
-        "http://www.re3data.org/repository/r3d1000000xx",
+        "https://www.re3data.org/repository/r3d1000000xx",
         "https://twitter.com/SDRO",
         "https://www.linkedin.com/company/123456789/"
     ],
@@ -70,7 +70,7 @@ If you are using the "@id" attribute for your Repository, and the provider of th
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": ["Service", "ResearchProject"],
   <strong>"@id": "https://www.sample-data-repository.org",</strong>
@@ -93,7 +93,7 @@ However, if your repository has a situation where multiple organizations act as 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -126,7 +126,7 @@ Adding additional fields of [schema:ResearchProject](https://schema.org/Research
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -168,7 +168,7 @@ If this ResearchProject, or Organization, has a parent entity such as a college,
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -184,10 +184,10 @@ If this ResearchProject, or Organization, has a parent entity such as a college,
   },
    <strong>"parentOrganization": {
      "@type": "Organization",
-     "@id": "http://www.someinstitute.edu",
+     "@id": "https://www.someinstitute.edu",
      "legalName": "Some Institute",
      "name": "SI",
-     "url": "http://www.someinstitute.edu",
+     "url": "https://www.someinstitute.edu",
      "address": {
        "@type": "PostalAddress",
        "streetAddress": "234 Main St.",
@@ -213,8 +213,8 @@ Some organizations may have a persistent identifier (DOI) assigned to their orga
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    <strong>"datacite": "http://purl.org/spar/datacite/"</strong>
+    "@vocab": "https://schema.org/",
+    <strong>"datacite": "https://purl.org/spar/datacite/"</strong>
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -231,14 +231,14 @@ Some organizations may have a persistent identifier (DOI) assigned to their orga
   <strong>"identifier": {
     "@type": "PropertyValue",
     "name": "Re3data DOI for this repository",
-    "propertyID": "http://purl.org/spar/datacite/doi",
+    "propertyID": "https://purl.org/spar/datacite/doi",
     "value": "10.17616/R37P4C",
     "url": "https://doi.org/10.17616/R37P4C"
   }</strong>
 }
 </pre>
 
-We add the `datacite` vocabulary to the `@context` because the Datacite Ontology available at [http://purl.org/spar/datacite/](http://purl.org/spar/datacite/) has URIs to describe a DOI, ORCiD, ARK, URI, URN - all identifier scheme that help for disamiguating identifiers. To properly disambiguate a globally unique identifier, 2 pieces of information are needed - 1) the identifier value and 2) the scheme that on which that identifier exists. Some examples of this concept for common identifiers  are:
+We add the `datacite` vocabulary to the `@context` because the Datacite Ontology available at [https://purl.org/spar/datacite/](https://purl.org/spar/datacite/) has URIs to describe a DOI, ORCiD, ARK, URI, URN - all identifier scheme that help for disamiguating identifiers. To properly disambiguate a globally unique identifier, 2 pieces of information are needed - 1) the identifier value and 2) the scheme that on which that identifier exists. Some examples of this concept for common identifiers  are:
 
 | Scheme | Value |
 | ------ | ----- |
@@ -265,8 +265,8 @@ To describe the funding source of a repository, you use the [schema:funder](http
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    <strong>"datacite": "http://purl.org/spar/datacite/",</strong>
+    "@vocab": "https://schema.org/",
+    <strong>"datacite": "https://purl.org/spar/datacite/",</strong>
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -282,10 +282,10 @@ To describe the funding source of a repository, you use the [schema:funder](http
   },
    "parentOrganization": {
      "@type": "Organization",
-     "@id": "http://www.someinstitute.edu",
+     "@id": "https://www.someinstitute.edu",
      "legalName": "Some Institute",
      "name": "SI",
-     "url": "http://www.someinstitute.edu",
+     "url": "https://www.someinstitute.edu",
      "address": {
        "@type": "PostalAddress",
        "streetAddress": "234 Main St.",
@@ -308,10 +308,10 @@ To describe the funding source of a repository, you use the [schema:funder](http
       },
       "parentOrganization": {
         "@type": "Organization",
-        "@id": "http://doi.org/10.13039/100000085",
+        "@id": "https://doi.org/10.13039/100000085",
         "legalName": "Directorate for Geosciences",
         "alternateName": "NSF-GEO",
-        "url": "http://www.nsf.gov",
+        "url": "https://www.nsf.gov",
         "identifier": {
           "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
           "propertyID": "DOI",
@@ -320,10 +320,10 @@ To describe the funding source of a repository, you use the [schema:funder](http
          },
         "parentOrganization": {
           "@type": "Organization",
-          "@id": "http://dx.doi.org/10.13039/100000001",
+          "@id": "https://dx.doi.org/10.13039/100000001",
           "legalName": "National Science Foundation",
           "alternateName": "NSF",
-          "url": "http://www.nsf.gov",
+          "url": "https://www.nsf.gov",
           "identifier": {
             "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
             "propertyID": "DOI",
@@ -350,8 +350,8 @@ For repositories might offer services for accessing data as opposed to directly 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -395,8 +395,8 @@ If your repository has a concept of a data collection, some grouping of a number
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": ["Service", "ResearchProject"],
   "legalName": "Sample Data Repository Office",
@@ -446,7 +446,7 @@ The SWEET ontology defines a number of science disciplines and a repository coul
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
+    "@vocab": "https://schema.org/",
     <strong>"sweet-rel": "http://sweetontology.net/rela/",
     "sweet-kd": "http://sweetontology.net/humanKnowledgeDomain/"</strong>
   },

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -32,7 +32,7 @@ Google has drafted a [guide to help publishers](https://developers.google.com/se
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   <strong>"name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -56,7 +56,7 @@ The [guide](https://developers.google.com/search/docs/data-types/dataset) sugges
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -66,7 +66,7 @@ The [guide](https://developers.google.com/search/docs/data-types/dataset) sugges
   "version": "2013-11-21",
   "isAccessibleForFree": true,
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/"</strong>
+  "license": "https://creativecommons.org/licenses/by/4.0/"</strong>
 }
 </pre>
 Back to [top](#top)
@@ -82,7 +82,7 @@ In it's most basic form, the identifier as text can be published as:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -91,7 +91,7 @@ In it's most basic form, the identifier as text can be published as:
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
   <strong>"identifier": "urn:sdro:dataset:472032"</strong>
 }
 </pre>
@@ -100,12 +100,12 @@ Or as a URL:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
   ...
-  <strong>"identifier": "http://id.sampledatarepository.org/dataset/472032/version/1"</strong>
+  <strong>"identifier": "https://id.sampledatarepository.org/dataset/472032/version/1"</strong>
 }
 </pre>
 
@@ -116,8 +116,8 @@ For identifiers that do have a well-defined scheme that scopes the identifier va
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    <strong>"datacite": "http://purl.org/spar/datacite/"</strong>
+    "@vocab": "https://schema.org/",
+    <strong>"datacite": "https://purl.org/spar/datacite/"</strong>
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -126,7 +126,7 @@ For identifiers that do have a well-defined scheme that scopes the identifier va
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
   <strong>"identifier": {
     "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
     "datacite:usesIdentifierScheme": { "@id": "datacite:doi" },
@@ -144,8 +144,8 @@ NOTE: If you have a DOI, the citation text can be [automatically generated](http
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    <strong>"datacite": "http://purl.org/spar/datacite/"</strong>
+    "@vocab": "https://schema.org/",
+    <strong>"datacite": "https://purl.org/spar/datacite/"</strong>
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -154,11 +154,11 @@ NOTE: If you have a DOI, the citation text can be [automatically generated](http
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
+  "license": "https://creativecommons.org/licenses/by/4.0/",
   "identifier": {
     "@id": "https://doi.org/10.1575/1912/bco-dmo.665253",
     "@type": ["PropertyValue", "datacite:Identifier"],
-    "propertyID": "http://purl.org/spar/datacite/doi",
+    "propertyID": "https://purl.org/spar/datacite/doi",
     "url": "https://doi.org/10.1575/1912/bco-dmo.665253",
     "value": "10.1575/1912/bco-dmo.665253"
    },
@@ -179,7 +179,7 @@ In it's most basic form, the variable as a [schema:PropertyValue](https://schema
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/"
+    "@vocab": "https://schema.org/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -200,8 +200,8 @@ A fully-fleshed out example that uses a vocabulary to describe the variable can 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/",
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/",
     <strong>"gsn-quantity": "http://www.geoscienceontology.org/geo-lower/quantity#"</strong>
   },
   "@type": "Dataset",
@@ -239,8 +239,8 @@ In the dataset JSON-LD, we reuse that `@id` to say a dataset belongs in that cat
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -264,8 +264,8 @@ An example of a MediaObject reference to an instance of ISO TC211 structured met
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -273,7 +273,7 @@ An example of a MediaObject reference to an instance of ISO TC211 structured met
   <strong>"encoding":{
     "@type":"MediaObject",
     "contentUrl":"https://example.org/link/to/metadata.xml",
-    "encodingFormat":"http://www.isotc211.org/2005/gmd",
+    "encodingFormat":"https://www.isotc211.org/2005/gmd",
     "description":"ISO TC211 XML rendering of metadata.",
     "dateModified":"2019-06-12T14:44:15Z"
   }</strong>
@@ -287,21 +287,21 @@ A SHACL shape graph for verifying the presence and structure of a MediaObject:
 ```turtle
 # Shape to evaluate schema:MediaObject instances that provide the value of
 # schema:encoding for an instance of schema:Dataset
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix schema: <http://schema.org/> .
-@prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix d1: <http://ns.dataone.org/schema/2019/08/SO/Dataset#> .
+@prefix rdf: <https://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix schema: <https://schema.org/> .
+@prefix sh: <https://www.w3.org/ns/shacl#> .
+@prefix xsd: <https://www.w3.org/2001/XMLSchema#> .
+@prefix d1: <https://ns.dataone.org/schema/2019/08/SO/Dataset#> .
 
 d1:rdfPrefix
   sh:declare [
-    sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+    sh:namespace "https://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
     sh:prefix "rdf" ;
   ] .
 
 d1:schemaPrefix
   sh:declare [
-    sh:namespace "http://schema.org/"^^xsd:anyURI ;
+    sh:namespace "https://schema.org/"^^xsd:anyURI ;
     sh:prefix "schema" ;
   ] .
 
@@ -339,7 +339,7 @@ d1:MediaObjectShape
 .
 ```
 *Note:* The aforementioned SHACL shape uses capabilities from the
-[advanced SHACL specification](https://www.w3.org/TR/shacl-af/#SPARQLTarget) which are not implemented by many SHACL validation libraries (including [pySHACL as of this writing](https://github.com/RDFLib/pySHACL/blob/49650b0c483d3fa5e9ab133df5694b739421a8f9/FEATURES.md)). The [TopBraid SHACL commandline validator](https://github.com/TopQuadrant/shacl) implements the required functionality. A simple wrapper in Python is available, see [pyTBSHACL](https://github.com/datadavev/pyTBSHACL). 
+[advanced SHACL specification](https://www.w3.org/TR/shacl-af/#SPARQLTarget) which are not implemented by many SHACL validation libraries (including [pySHACL as of this writing](https://github.com/RDFLib/pySHACL/blob/49650b0c483d3fa5e9ab133df5694b739421a8f9/FEATURES.md)). The [TopBraid SHACL commandline validator](https://github.com/TopQuadrant/shacl) implements the required functionality. A simple wrapper in Python is available, see [pyTBSHACL](https://github.com/datadavev/pyTBSHACL).
 
 Back to [top](#top)
 
@@ -354,8 +354,8 @@ For data available in multipe formats, there will be multiple values of the [sch
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -378,8 +378,8 @@ If access to the data requires some input parameters before a download can occur
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -442,8 +442,8 @@ To represent a single date and time:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -476,15 +476,15 @@ Or an open-ended date range _(thanks to [@lewismc](https://github.com/lewismc) f
 }
 </pre>
 
-Schema.org also lets you provide date ranges and other temporal coverages through the [DateTime](http://schema.org/DateTime) data type and [URL](http://schema.org/URL). For more granular temporal coverages go here: [http://schema.org/DateTime](http://schema.org/DateTime).
+Schema.org also lets you provide date ranges and other temporal coverages through the [DateTime](https://schema.org/DateTime) data type and [URL](https://schema.org/URL). For more granular temporal coverages go here: [https://schema.org/DateTime](https://schema.org/DateTime).
 
 One example of a URL temporal coverage might be for named periods in time:
 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -523,8 +523,8 @@ A point, or coordinate, would defined in this way:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -596,21 +596,21 @@ If you have multiple geometries, you can publish those by making the [schema:geo
 
 
 <a id="spatial_reference-system"></a>
-A Spatial Reference System (SRS) or Coordinate reference systems (CRS) are methodologies for locating geographical features within some frame of reference (e.g. Earth, Moon, etc.). To represent an SRS in schema.org, we should use the `[schema:additionalProperty](http://schema.org/additionalProperty)` property to specify an object of type `[schema:PropertyValue](http://schema.org/PropertyValue)` and `[dbpedia:Spatial_reference_system](http://dbpedia.org/resource/Spatial_reference_system)`, a decent RDF resource on the web for describing what an SRS is.
+A Spatial Reference System (SRS) or Coordinate reference systems (CRS) are methodologies for locating geographical features within some frame of reference (e.g. Earth, Moon, etc.). To represent an SRS in schema.org, we should use the `[schema:additionalProperty](https://schema.org/additionalProperty)` property to specify an object of type `[schema:PropertyValue](https://schema.org/PropertyValue)` and `[dbpedia:Spatial_reference_system](https://dbpedia.org/resource/Spatial_reference_system)`, a decent RDF resource on the web for describing what an SRS is.
 
-| Spatial Reference System | IRI                                          |
-|--------------------------|----------------------------------------------|
-| WGS84                    | http://www.w3.org/2003/01/geo/wgs84_pos#     |
-| CRS84                    | http://www.opengis.net/def/crs/OGC/1.3/CRS84 |
+| Spatial Reference System | IRI                                           |
+|--------------------------|-----------------------------------------------|
+| WGS84                    | https://www.w3.org/2003/01/geo/wgs84_pos#     |
+| CRS84                    | https://www.opengis.net/def/crs/OGC/1.3/CRS84 |
 
 A spatial reference system can be added in this way:
 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/",
-    <strong>"dbpedia": "http://dbpedia.org/resource/"</strong>
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/",
+    <strong>"dbpedia": "https://dbpedia.org/resource/"</strong>
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -623,7 +623,7 @@ A spatial reference system can be added in this way:
     },
     <strong>"additionalProperty": {
       "@type": ["PropertyValue", "dbpedia:Spatial_reference_system"],
-      "@id": "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+      "@id": "https://www.opengis.net/def/crs/OGC/1.3/CRS84"
     }</strong>
   }
 }
@@ -633,22 +633,22 @@ Back to [top](#top)
 
 ### Roles of People
 
-People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields of creator and contribulds of creator and contributor. But using any of these fields are okay. Becuase there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
+People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields of creator and contribulds of creator and contributor. But using any of these fields are okay. Becuase there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](https://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
 
 ![People Roles](/assets/diagrams/dataset/dataset_people-roles.svg "Dataset - People Roles")
 
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
   ...
   <strong>"creator": [
     {
-      "@id": "http://lod.bco-dmo.org/id/person-role/472036",
+      "@id": "https://lod.bco-dmo.org/id/person-role/472036",
       "@type": "Role",
       "roleName": "Principal Investigator",
       "creator": {
@@ -661,7 +661,7 @@ People can be linked to datasets using three fields: author, creator, and contri
       }
     },
     {
-      "@id": "http://lod.bco-dmo.org/id/person-role/472038",
+      "@id": "https://lod.bco-dmo.org/id/person-role/472038",
       "@type": "Role",
       "roleName": "Co-Principal Investigator",
       "url": "https://www.bco-dmo.org/person-role/472038",
@@ -670,7 +670,7 @@ People can be linked to datasets using three fields: author, creator, and contri
         "@type": "Person",
         "identifier": {
           "@type": ["PropertyValue", "datacite:Identifier"],
-          "propertyID": "http://purl.org/spar/datacite/orcid",
+          "propertyID": "https://purl.org/spar/datacite/orcid",
           "url": "https://orcid.org/0000-0003-3432-2297",
           "value": "0000-0003-3432-2297"
         },
@@ -685,17 +685,17 @@ NOTE that the Role inherits the property `creator` and `contributor` from the Da
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
+    "@vocab": "https://schema.org/",
     ...
   },
   <strong>"@type": "Dataset"</strong>,
   ...
   <strong>"creator"</strong>: [
     {
-      "@id": "http://lod.bco-dmo.org/id/person-role/472036",
+      "@id": "https://lod.bco-dmo.org/id/person-role/472036",
       <strong>"@type": "Role"</strong>,
       "roleName": "Principal Investigator",
-      "url": "http://lod.bco-dmo.org/id/person-role/472036",
+      "url": "https://lod.bco-dmo.org/id/person-role/472036",
       <strong>"creator":</strong> {
         "@id": "https://www.bco-dmo.org/person/51317",
         "@type": "Person",
@@ -713,18 +713,18 @@ If a single Person plays multiple roles on a Dataset, each role should be explic
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
   ...
   "creator": [
     {
-      "@id": "http://lod.bco-dmo.org/id/person-role/472036",
+      "@id": "https://lod.bco-dmo.org/id/person-role/472036",
       "@type": "Role",
       "roleName": "Principal Investigator",
-      "url": "http://lod.bco-dmo.org/id/person-role/472036",
+      "url": "https://lod.bco-dmo.org/id/person-role/472036",
       "creator": {
         <strong>"@id": "https://www.bco-dmo.org/person/51317"</strong>,
         "@type": "Person",
@@ -742,7 +742,7 @@ If a single Person plays multiple roles on a Dataset, each role should be explic
       "creator": { "@id": "https://www.bco-dmo.org/person/51317" }
     }</strong>,
     {
-      "@id": "http://lod.bco-dmo.org/id/person-role/472038",
+      "@id": "https://lod.bco-dmo.org/id/person-role/472038",
       "@type": "Role",
       "roleName": "Co-Principal Investigator",
       "url": "https://www.bco-dmo.org/person-role/472038",
@@ -751,7 +751,7 @@ If a single Person plays multiple roles on a Dataset, each role should be explic
         "@type": "Person",
         "identifier": {
           "@type": ["PropertyValue", "datacite:Identifier"],
-          "propertyID": "http://purl.org/spar/datacite/orcid",
+          "propertyID": "https://purl.org/spar/datacite/orcid",
           "url": "https://orcid.org/0000-0003-3432-2297",
           "value": "0000-0003-3432-2297"
         },
@@ -786,8 +786,8 @@ then you can reuse that `@id` here. Harvesters such as Google and Project418 wil
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -806,8 +806,8 @@ Otherwise, you can define the organization inline in this way:
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
@@ -817,7 +817,7 @@ Otherwise, you can define the organization inline in this way:
     "@type": "Organization",
     "legalName": "Sample Data Repository Office",
     "name": "SDRO",
-    "sameAs": "http://www.re3data.org/repository/r3dxxxxxxxxx",
+    "sameAs": "https://www.re3data.org/repository/r3dxxxxxxxxx",
     "url": "https://www.sample-data-repository.org"
   },
   "publisher": {
@@ -836,10 +836,10 @@ Linking a Dataset to its funding can be acheived by adding a [schema:MonetaryGra
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
-  <strong>"@id": "http://www.sample-data-repository.org/dataset/123",</strong>
+  <strong>"@id": "https://www.sample-data-repository.org/dataset/123",</strong>
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
   ...
@@ -850,11 +850,11 @@ Next, we must make our JSON-LD allow multiple top-level items by using the `@gra
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   <strong>"@graph":[{</strong>
-      "@id": "http://www.sample-data-repository.org/dataset/123",
+      "@id": "https://www.sample-data-repository.org/dataset/123",
       "@type": "Dataset",
       "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
       ...
@@ -868,23 +868,23 @@ You can now see that the Dataset object `{}` is now the first element in the `@g
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@graph":[{
-      "@id": "http://www.sample-data-repository.org/dataset/123",
+      "@id": "https://www.sample-data-repository.org/dataset/123",
       "@type": "Dataset",
       "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
       ...
     }<strong>,
     {
       "@type": "MonetaryGrant",
-      "fundedItem": { "@id": "http://www.sample-data-repository.org/dataset/123" },
+      "fundedItem": { "@id": "https://www.sample-data-repository.org/dataset/123" },
       "name": "NSF Award# 143211",
       "funder": {
         "@type": "Organization",
         "name": "National Science Foundation",
-        "url": "http://www.nsf.gov"
+        "url": "https://www.nsf.gov"
       },
       "sameAs": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1435578",
       "identifier": "143211"
@@ -898,27 +898,27 @@ Now, because there are two top-level items on this webpage, harvesters will be u
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
-    "datacite": "http://purl.org/spar/datacite/"
+    "@vocab": "https://schema.org/",
+    "datacite": "https://purl.org/spar/datacite/"
   },
   "@graph":[{
-      "@id": "http://www.sample-data-repository.org/dataset/123",
+      "@id": "https://www.sample-data-repository.org/dataset/123",
       "@type": "Dataset",
       "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
       <strong>"mainEntityOfPage": {
          "@type": "WebPage",
-         "@id": "http://www.sample-data-repository.org/dataset/123"
+         "@id": "https://www.sample-data-repository.org/dataset/123"
       },</strong>
       ...
     },
     {
       "@type": "MonetaryGrant",
-      "fundedItem": { "@id": "http://www.sample-data-repository.org/dataset/123" },
+      "fundedItem": { "@id": "https://www.sample-data-repository.org/dataset/123" },
       "name": "NSF Award# 143211",
       "funder": {
         "@type": "Organization",
         "name": "National Science Foundation",
-        "url": "http://www.nsf.gov"
+        "url": "https://www.nsf.gov"
       },
       "sameAs": "https://www.nsf.gov/awardsearch/showAward?AWD_ID=1435578",
       "identifier": "143211"
@@ -940,10 +940,10 @@ Currently, there isn't a great semantic property for a Dataset to distinguish th
 <pre>
 {
   "@context": {
-    "@vocab": "http://schema.org/",
+    "@vocab": "https://schema.org/",
     "gdx": "https://geodex.org/voc/",
-    <strong>"geolink": "http://schema.geolink.org/1.0/base/main#",
-    "igsn": "http://pid.geoscience.gov.au/def/voc/igsn-codelists/",</strong>
+    <strong>"geolink": "https://schema.geolink.org/1.0/base/main#",
+    "igsn": "https://pid.geoscience.gov.au/def/voc/igsn-codelists/",</strong>
   },
   "@type": "Dataset",
   ...,

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -287,15 +287,15 @@ A SHACL shape graph for verifying the presence and structure of a MediaObject:
 ```turtle
 # Shape to evaluate schema:MediaObject instances that provide the value of
 # schema:encoding for an instance of schema:Dataset
-@prefix rdf: <https://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix schema: <https://schema.org/> .
-@prefix sh: <https://www.w3.org/ns/shacl#> .
-@prefix xsd: <https://www.w3.org/2001/XMLSchema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix d1: <https://ns.dataone.org/schema/2019/08/SO/Dataset#> .
 
 d1:rdfPrefix
   sh:declare [
-    sh:namespace "https://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
+    sh:namespace "http://www.w3.org/1999/02/22-rdf-syntax-ns#"^^xsd:anyURI ;
     sh:prefix "rdf" ;
   ] .
 
@@ -339,7 +339,7 @@ d1:MediaObjectShape
 .
 ```
 *Note:* The aforementioned SHACL shape uses capabilities from the
-[advanced SHACL specification](https://www.w3.org/TR/shacl-af/#SPARQLTarget) which are not implemented by many SHACL validation libraries (including [pySHACL as of this writing](https://github.com/RDFLib/pySHACL/blob/49650b0c483d3fa5e9ab133df5694b739421a8f9/FEATURES.md)). The [TopBraid SHACL commandline validator](https://github.com/TopQuadrant/shacl) implements the required functionality. A simple wrapper in Python is available, see [pyTBSHACL](https://github.com/datadavev/pyTBSHACL).
+[advanced SHACL specification](http://www.w3.org/TR/shacl-af/#SPARQLTarget) which are not implemented by many SHACL validation libraries (including [pySHACL as of this writing](https://github.com/RDFLib/pySHACL/blob/49650b0c483d3fa5e9ab133df5694b739421a8f9/FEATURES.md)). The [TopBraid SHACL commandline validator](https://github.com/TopQuadrant/shacl) implements the required functionality. A simple wrapper in Python is available, see [pyTBSHACL](https://github.com/datadavev/pyTBSHACL).
 
 Back to [top](#top)
 
@@ -600,7 +600,7 @@ A Spatial Reference System (SRS) or Coordinate reference systems (CRS) are metho
 
 | Spatial Reference System | IRI                                           |
 |--------------------------|-----------------------------------------------|
-| WGS84                    | https://www.w3.org/2003/01/geo/wgs84_pos#     |
+| WGS84                    | http://www.w3.org/2003/01/geo/wgs84_pos#     |
 | CRS84                    | https://www.opengis.net/def/crs/OGC/1.3/CRS84 |
 
 A spatial reference system can be added in this way:

--- a/guides/GETTING-STARTED.md
+++ b/guides/GETTING-STARTED.md
@@ -33,30 +33,30 @@ To provide a place for the scientific data community to work out how best to imp
 1. To be **pragmatic** with our use of schema.org and external vocabulary adoption.
 2. To **consider schema.org classes and properties first** before considering external vocabularies.
 3. Use **[JSON-LD](https://json-ld.org/)** in our guidance documents for simplicity and terseness as compared to *[Microdata](https://www.w3.org/TR/microdata/)* and *[RDFa](https://rdfa.info/)*. For more, see [Why JSON-LD?](/CONVENTIONS.md#why-jsonld) from the [Conventions](/CONVENTIONS.md) document.
-4. Presently, the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) enforces use of [schema.org](http://schema.org) classes and properties by displaying an error whenever external vocabularies are used. schema.org proposes linking to external vocabularies usuing the [schema:additionalType](http://schema.org/additionalType) property. While this property is defined as a sub property of [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), it's data type is a literal. We encourage the use of JSON-LD ```'@type'``` for typing classes to external vocabularies. For more, see [Typing to External Vocabularies](/CONVENTIONS.md#external-vocab-typing) from the [Conventions](/CONVENTIONS.md) document.
+4. Presently, the [Google Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) enforces use of [schema.org](https://schema.org) classes and properties by displaying an error whenever external vocabularies are used. schema.org proposes linking to external vocabularies usuing the [schema:additionalType](https://schema.org/additionalType) property. While this property is defined as a sub property of [rdf:type](https://www.w3.org/1999/02/22-rdf-syntax-ns#type), it's data type is a literal. We encourage the use of JSON-LD ```'@type'``` for typing classes to external vocabularies. For more, see [Typing to External Vocabularies](/CONVENTIONS.md#external-vocab-typing) from the [Conventions](/CONVENTIONS.md) document.
 5. See [Governance](/GOVERNANCE.md) for how we will govern the project.
 6. See [Conventions](/CONVENTIONS.md) for guidance on creating/editing guidance documents.
 
 <a id="prerequisites"></a>
 ## Prerequisites ##
 
-1. We assume a general understanding of [JSON](http://www.json.org/). 
+1. We assume a general understanding of [JSON](https://www.json.org).
 2. We assume a basic knowledge about [JSON-LD](https://json-ld.org).
 
   JSON-LD is valid JSON, so standard developer tools that support JSON can be used. For some specific JSON-LD and schema.org help though, there are some other resources.
 
   ##### JSON-LD resources  https://json-ld.org
-  Generating the JSON-LD is best done via libraries like those you can find at https://json-ld.org.  
+  Generating the JSON-LD is best done via libraries like those you can find at https://json-ld.org.
   There are libraries for; Javascript, Python, PHP, Ruby, Java, C# and Go.  While JSON-LD is just
-  JSON and can be generated many ways, these libraries 
-  can generate valid JSON-LD spec output.   
+  JSON and can be generated many ways, these libraries
+  can generate valid JSON-LD spec output.
 
   ##### JSON-LD playground https://json-ld.org/playground/
-  The playground is hosted at the very useful [JSON-LD web site](https://json-ld.org) site. You 
+  The playground is hosted at the very useful [JSON-LD web site](https://json-ld.org) site. You
   can explore examples of JSON-LD and view how they convert to RDF, flatten, etc.   Note, that JSON-LD
-  is not associated with schema.org.  It can be used for much more and so most examples here don't 
+  is not associated with schema.org.  It can be used for much more and so most examples here don't
   use schema.org and this site will NOT look to see if you are using schema.org types and properties
-  correctly.  Only that your JSON-LD is well formed.  
+  correctly.  Only that your JSON-LD is well formed.
 
 3. We assume that you've heard about [schema.org](https://schema.org) and have already decided that it's useful to you.
 4. We assume that you have a general understanding of what may describe a scientific dataset.
@@ -65,10 +65,10 @@ Let's go!
 
 <a id="introduction"></a>
 ## Introduction ##
-There is an emerging practice to leverage structured metadata to aid in the discovery of web based resources.  Much of this 
-work is taking place in the context (no pun intended) of schema.org.  This approach has extended to the resource type Dataset. 
-This page will present approaches, tools and references that will aid in the understanding and development of schema.org in 
-JSON-LD and its connection to external vocabularies.  For a more thorough presentation on this visit the Google AI Blog entry 
+There is an emerging practice to leverage structured metadata to aid in the discovery of web based resources.  Much of this
+work is taking place in the context (no pun intended) of schema.org.  This approach has extended to the resource type Dataset.
+This page will present approaches, tools and references that will aid in the understanding and development of schema.org in
+JSON-LD and its connection to external vocabularies.  For a more thorough presentation on this visit the Google AI Blog entry
 of January 24 2017 at https://ai.googleblog.com/2017/01/facilitating-discovery-of-public.html .
 
 <a id="using-schemaorg"></a>
@@ -76,7 +76,7 @@ of January 24 2017 at https://ai.googleblog.com/2017/01/facilitating-discovery-o
 
 <a id="using-schemaorg_adding-jsonld-webpages"></a>
 ### Modifying web pages to include schema.org as JSON-LD ###
-JSON-LD should be incorporated into the landing page html inside the `<head></head>` as a `<script>` element.  
+JSON-LD should be incorporated into the landing page html inside the `<head></head>` as a `<script>` element.
 
 ```
 <html>
@@ -85,9 +85,9 @@ JSON-LD should be incorporated into the landing page html inside the `<head></he
     <script id="schemaorg" type="application/ld+json">
     {
       "@context": {
-        "@vocab": "http://schema.org/"
+        "@vocab": "https://schema.org/"
        },
-       "@id": "http://opencoredata.org/id/dataset/bcd15975-680c-47db-a062-ac0bb6e66816",
+       "@id": "https://opencoredata.org/id/dataset/bcd15975-680c-47db-a062-ac0bb6e66816",
        "@type": "Dataset",
        "description": "Janus Thermal Conductivity for ocean drilling ...",
        ...
@@ -98,7 +98,7 @@ JSON-LD should be incorporated into the landing page html inside the `<head></he
   ...
 </html>
  ```
- 
+
 <a id="data-types"></a>
 ### Data Types ###
 
@@ -124,11 +124,11 @@ Every data type is either a *resource* or a *literal*. Resources refer to other 
 }
 </pre>
 
-In the JSON-LD above, the 'author' is a resource of type 'Person'. Fields that simply have a value are called literal data types. For examples, the 'Person' type above has a 'name' of "Jane Goodall" - a literal text value. 
+In the JSON-LD above, the 'author' is a resource of type 'Person'. Fields that simply have a value are called literal data types. For examples, the 'Person' type above has a 'name' of "Jane Goodall" - a literal text value.
 
-Schema.org defines six literal, or primitive,  data types: [Text](https://schema.org/Text), [Number](https://schema.org/Number), [Boolean](https://schema.org/Boolean), [Date](https://schema.org/Date), [DateTime](https://schema.org/DateTime), and [Time](https://schema.org/Time). [Text](https://schema.org/Text) has two special variations: [URL](https://schema.org/URL) and how to specify when text is actually [HTML](#data-type_HTML).  
+Schema.org defines six literal, or primitive,  data types: [Text](https://schema.org/Text), [Number](https://schema.org/Number), [Boolean](https://schema.org/Boolean), [Date](https://schema.org/Date), [DateTime](https://schema.org/DateTime), and [Time](https://schema.org/Time). [Text](https://schema.org/Text) has two special variations: [URL](https://schema.org/URL) and how to specify when text is actually [HTML](#data-type_HTML).
 
-When using schema.org, literal data types are not not specified using curly brackets ```{}``` as these are resrved for specifying 'objects' or 'resources' such as other schema.org types like ```Person```, ```Organization```, etc. First, let's see how to use a primitive data type by using fields of [CreativeWork](https://schema.org/CreativeWork), the superclass for [Dataset](https://schema.org/Dataset). 
+When using schema.org, literal data types are not not specified using curly brackets ```{}``` as these are resrved for specifying 'objects' or 'resources' such as other schema.org types like ```Person```, ```Organization```, etc. First, let's see how to use a primitive data type by using fields of [CreativeWork](https://schema.org/CreativeWork), the superclass for [Dataset](https://schema.org/Dataset).
 
 <a id="data-types_Text"></a>
 #### Text ####
@@ -240,7 +240,7 @@ To specify the [dateModified](https://schema.org/dateModified) as a DateTime, as
 <a id="data-types_HTML"></a>
 #### HTML ####
 
-The HTML data type is a special variation of the ```Text``` data type. In some cases where `Text` is the expected data type, our actual data type may be HTML (because we are dealing with web pages). In this case, the [schema.org JSON-LD context](https://schema.org/docs/jsonldcontext.json) defines ```HTML``` to mean [rdf:HTML](http://www.w3.org/1999/02/22-rdf-syntax-ns#HTML), the data type for specifying that a string of text should be interpreted as HTML. Let's say that we have a description of our manifest and want to use the [description](https://schema.org/description) field, but we have HTML inside that text. Using the text field as we did above for the ```name``` field, we would specify the ```description``` as: 
+The HTML data type is a special variation of the ```Text``` data type. In some cases where `Text` is the expected data type, our actual data type may be HTML (because we are dealing with web pages). In this case, the [schema.org JSON-LD context](https://schema.org/docs/jsonldcontext.json) defines ```HTML``` to mean [rdf:HTML](https://www.w3.org/1999/02/22-rdf-syntax-ns#HTML), the data type for specifying that a string of text should be interpreted as HTML. Let's say that we have a description of our manifest and want to use the [description](https://schema.org/description) field, but we have HTML inside that text. Using the text field as we did above for the ```name``` field, we would specify the ```description``` as:
 
 <pre>
 {
@@ -268,9 +268,9 @@ However, to specify that the ```description``` field should be *interpreted* as 
   "isAccessibleForFree": true,
   "datePublished": "2018-07-29",
   "dateModified": "2018-07-30T14:30Z",
-  "description": { 
-    <strong>"@type": "HTML", 
-    "@value": "&lt;h3&gt;Acquisition&lt;/h3&gt;&lt;p&gt;The data was acquired from an office outside of &lt;a href\"https://en.wikipedia.org/wiki/New_York_City\"&gt;New York City&lt;/a&gt;."</strong> 
+  "description": {
+    <strong>"@type": "HTML",
+    "@value": "&lt;h3&gt;Acquisition&lt;/h3&gt;&lt;p&gt;The data was acquired from an office outside of &lt;a href\"https://en.wikipedia.org/wiki/New_York_City\"&gt;New York City&lt;/a&gt;."</strong>
   }
 }
 </pre>


### PR DESCRIPTION
This PR changes all occurrences of http to https, unless the linked website is only available with http or the http is used in an example explicitly as http (e.g. http://doi.org/... vs. https://doi.org/...).
I also ensured trailing slashes for addresses used as `@vocab` (one change in CONVENTIONS.md).

This addresses issue #52.

As a side effect of my editor, trailing spaces are also deleted.