### PR TITLE
Feature 47 use spdx licenses

### DIFF
--- a/decisions/47-use-spdx-licenses.md
+++ b/decisions/47-use-spdx-licenses.md
@@ -26,7 +26,7 @@ Link a Dataset to its license to document legal constraints by adding a [schema:
 }
 </pre>
 
-While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses are an exception in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is acceptable.  Here's an example using the traditional CC URI for the license.
+While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses are an exception in that they provide consistent URIs for each license, and these are in widespread use.  While we recommend using the SPDX URI, it is acceptable to use the CC license URIs directly if preferred.  Here's an example using the traditional CC URI for the license.
 <pre>
 {
   "@context": {
@@ -77,7 +77,7 @@ Version 2.0, January 2004
 ...
 </pre>
 
-Finally, the SPDX project provides structured data files of the [SPDX license data](https://github.com/spdx/license-list-data) in machine readable formats, including turtle and json-ld.  These could be imported into COR or other vocabulary servers if we want a queryable graph of the license data.
+Finally, the SPDX project provides structured data files of the [SPDX license data](https://github.com/spdx/license-list-data) in machine readable formats, including turtle and json-ld.  These could be imported into COR or other vocabulary servers to provide a queryable graph of the license data.
 
 ## Consequences ##
 

--- a/decisions/47-use-spdx-licenses.md
+++ b/decisions/47-use-spdx-licenses.md
@@ -40,7 +40,7 @@ While many licenses are ambiguous about the license URI for the license, the Cre
 }
 </pre>
 
-One issue is that SPDX URIs currently resolve to a HTML landing page describing a license, rather than a machine-readable version of the license through content negotiation. However, the web page that is returned does contain structured markup in RDFa format indicating the structured license properties.  For example, the HTML page for the Apache-2.0 license contains property attributes for structured data for `spdx:License`, `spdx:deprecated`, `spdx:name`, `spdx:licenseId`, `rdfs:seeAlso`, `spdx:isOsiApproved`, and `spdx:licenseText`, among others. For example, here is the web snippet for the Apache-2.0 license:
+One issue is that SPDX URIs currently resolve to a HTML landing page describing a license, rather than a machine-readable version of the license through content negotiation. However, the web page that is returned does contain structured markup in RDFa format indicating the structured license properties.  For example, the HTML page for the [Apache-2.0 license](http://spdx.org/licenses/Apache-2.0) contains property attributes for structured data for `spdx:License`, `spdx:deprecated`, `spdx:name`, `spdx:licenseId`, `rdfs:seeAlso`, `spdx:isOsiApproved`, and `spdx:licenseText`, among others. For example, here is the web snippet for the Apache-2.0 license:
 
 <pre>
 &lt;h1 property="dc:title"&gt;Apache License 2.0&lt;/h1&gt;

--- a/decisions/47-use-spdx-licenses.md
+++ b/decisions/47-use-spdx-licenses.md
@@ -84,4 +84,4 @@ Finally, the SPDX project provides structured data files of the [SPDX license da
 - We gain a comprehensive, maintained, unambiguous vocabulary for licenses, increasing consistency across repositories
 - We gain compatibility with the software packaging world like Debian and Python
 - Licenses that have well-known URIs (e.g., Creative Commons) may be less recognizable by their SPDX URI
-- SPDX license URIs only resolve to HTML pages, not machine-readable representations 
+- SPDX license URIs only resolve to HTML pages with machine-readable RDFa embedded, but machine-readable representations in other formats do not seem to be available through content negotiation

--- a/decisions/47-use-spdx-licenses.md
+++ b/decisions/47-use-spdx-licenses.md
@@ -1,0 +1,87 @@
+# Use SPDX license vocabulary for URIs
+
+Discussion: https://github.com/ESIPFed/science-on-schema.org/issues/47
+
+## Status ##
+_Proposed_
+
+## Decision ##
+
+Use SPDX license URIs to unambiguously specify the license for data and metadata use.
+
+## Context ##
+
+Link a Dataset to its license to document legal constraints by adding a [schema:license](https://schema.org/license) property. The [guide](https://developers.google.com/search/docs/data-types/dataset) recommends providing a URL that unambiguously identifies a specific version of the license used, but for many licenses it is hard to determine what that URL should be. Thus, we recommend that the license URL be drawn from the [SPDX license list](https://spdx.org/licenses/), which provides a curated list of licenses and their properties that is well maintained. For each SPDX entry, SPDX provides a canonical URL for the license (e.g., `http://spdx.org/licenses/CC0-1.0`), a unique `licenseId` (e.g., `CC0-1.0`), and other metadata about the license. Here's an example using the SPDX license URI for the Creative Commons CC-0 license:
+
+<pre>
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+  },
+  "@id": "http://www.sample-data-repository.org/dataset/123",
+  "@type": "Dataset",
+  "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
+  <strong>"license": "http://spdx.org/licenses/CC0-1.0"</strong>
+  ...
+}
+</pre>
+
+While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses are an exception in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is acceptable.  Here's an example using the traditional CC URI for the license.
+<pre>
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+  },
+  "@id": "http://www.sample-data-repository.org/dataset/123",
+  "@type": "Dataset",
+  "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
+  <strong>"license": "https://creativecommons.org/publicdomain/zero/1.0"</strong>
+  ...
+}
+</pre>
+
+One issue is that SPDX URIs currently resolve to a HTML landing page describing a license, rather than a machine-readable version of the license through content negotiation. However, the web page that is returned does contain structured markup in RDFa format indicating the structured license properties.  For example, the HTML page for the Apache-2.0 license contains property attributes for structured data for `spdx:License`, `spdx:deprecated`, `spdx:name`, `spdx:licenseId`, `rdfs:seeAlso`, `spdx:isOsiApproved`, and `spdx:licenseText`, among others. For example, here is the web snippet for the Apache-2.0 license:
+
+<pre>
+&lt;h1 property="dc:title"&gt;Apache License 2.0&lt;/h1&gt;
+&lt;div style="display:none;"&gt;&lt;code property="spdx:deprecated"&gt;false&lt;/code&gt;&lt;/div&gt;
+&lt;h2&gt;Full name&lt;/h2&gt;
+    &lt;p style="margin-left: 20px;"&gt;&lt;code property="spdx:name"&gt;Apache License 2.0&lt;/code&gt;&lt;/p&gt;
+
+&lt;h2&gt;Short identifier&lt;/h2&gt;
+    &lt;p style="margin-left: 20px;"&gt;&lt;code property="spdx:licenseId"&gt;Apache-2.0&lt;/code&gt;&lt;/p&gt;
+
+&lt;h2&gt;Other web pages for this license&lt;/h2&gt;
+    &lt;div style="margin-left: 20px;"&gt;
+      &lt;ul&gt;
+       &lt;li&gt;&lt;a href="http://www.apache.org/licenses/LICENSE-2.0" rel="rdfs:seeAlso"&gt;http://www.apache.org/licenses/LICENSE-2.0&lt;/a&gt;&lt;/li&gt;
+       &lt;li&gt;&lt;a href="https://opensource.org/licenses/Apache-2.0" rel="rdfs:seeAlso"&gt;https://opensource.org/licenses/Apache-2.0&lt;/a&gt;&lt;/li&gt;
+     &lt;/ul&gt;
+    &lt;/div&gt;
+          
+&lt;div property="spdx:isOsiApproved" style="display: none;"&gt;true&lt;/div&gt;
+
+&lt;h2 id="notes"&gt;Notes&lt;/h2&gt;
+    &lt;p style="margin-left: 20px;"&gt;This license was released January 2004&lt;/p&gt;
+
+&lt;h2 id="licenseText"&gt;Text&lt;/h2&gt;
+
+&lt;div property="spdx:licenseText" class="license-text"&gt;
+      
+&lt;div class="optional-license-text"&gt;
+   &lt;p&gt;Apache License
+  &lt;br /&gt;
+
+Version 2.0, January 2004
+  &lt;br /&gt;
+...
+</pre>
+
+Finally, the SPDX project provides structured data files of the [SPDX license data](https://github.com/spdx/license-list-data) in machine readable formats, including turtle and json-ld.  These could be imported into COR or other vocabulary servers if we want a queryable graph of the license data.
+
+## Consequences ##
+
+- We gain a comprehensive, maintained, unambiguous vocabulary for licenses, increasing consistency across repositories
+- We gain compatibility with the software packaging world like Debian and Python
+- Licenses that have well-known URIs (e.g., Creative Commons) may be less recognizable by their SPDX URI
+- SPDX license URIs only resolve to HTML pages, not machine-readable representations 

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -18,6 +18,7 @@
 		- [Roles of People](#roles-of-people)
 		- [Publisher / Provider](#publisher-provider)
 		- [Funding](#funding)
+		- [License](#license)
 	- [Advanced Publishing Techniques](#advanced-publishing-techniques)
 		- [Attaching Physical Samples to a Dataset](#attaching-physical-samples-to-a-dataset)
 
@@ -929,6 +930,38 @@ Now, because there are two top-level items on this webpage, harvesters will be u
 
 Back to [top](#top)
 
+### License
+
+Link a Dataset to its license to document legal constraints by adding a [schema:license](https://schema.org/license) property. The [guide](https://developers.google.com/search/docs/data-types/dataset) recommends providing a URL that unambiguously identifies a specific version of the license used, but for many licenses it is hard to determine what that URL should be. Thus, we recommend that the license URL be drawn from the [SPDX license list](https://spdx.org/licenses/), which provides a curated list of licenses and their properties that is well maintained. For each SPDX entry, SPDX provides a canonical URL for the license (e.g., `http://spdx.org/licenses/CC0-1.0`), a unique `licenseId` (e.g., `CC0-1.0`), and other metadata about the license. Here's an example using the SPDX license URI for the Creative Commons CC-0 license:
+
+<pre>
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+  },
+  "@id": "http://www.sample-data-repository.org/dataset/123",
+  "@type": "Dataset",
+  "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
+  <strong>"license": "http://spdx.org/licenses/CC0-1.0"</strong>
+  ...
+}
+</pre>
+
+While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses are an exception in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is acceptable.  Here's an example using the traditional CC URI for the license.
+<pre>
+{
+  "@context": {
+    "@vocab": "https://schema.org/",
+  },
+  "@id": "http://www.sample-data-repository.org/dataset/123",
+  "@type": "Dataset",
+  "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
+  <strong>"license": "https://creativecommons.org/publicdomain/zero/1.0"</strong>
+  ...
+}
+</pre>
+
+Back to [top](#top)
 
 ## Advanced Publishing Techniques
 

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -48,7 +48,6 @@ The [guide](https://developers.google.com/search/docs/data-types/dataset) sugges
 * [version](https://schema.org/version) - The version number or identifier for this dataset (text or numeric).
 * [isAccessibleForFree](https://schema.org/isAccessibleForFree) - Boolean (true|false) speficying if the dataset is accessible for free.
 * [keywords](https://schema.org/keywords) - Keywords summarizing the dataset.
-* [license](https://schema.org/license) - A license under which the dataset is distributed (text or URL).
 * [identifier](https://schema.org/identifier) - An identifier for the dataset, such as a DOI. (text,URL, or PropertyValue).
 * [variableMeasured](https://schema.org/variableMeasured) - What does the dataset measure? (e.g., temperature, pressure)
 
@@ -66,8 +65,9 @@ The [guide](https://developers.google.com/search/docs/data-types/dataset) sugges
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "isAccessibleForFree": true,
-  "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/"</strong>
+  "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"]
+  "license": [ "http://spdx.org/licenses/CC0-1.0", "https://creativecommons.org/publicdomain/zero/1.0"]
+  </strong>
 }
 </pre>
 Back to [top](#top)
@@ -92,7 +92,6 @@ In it's most basic form, the identifier as text can be published as:
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
   <strong>"identifier": "urn:sdro:dataset:472032"</strong>
 }
 </pre>
@@ -127,7 +126,6 @@ For identifiers that do have a well-defined scheme that scopes the identifier va
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
   <strong>"identifier": {
     "@type": ["PropertyValue", "datacite:ResourceIdentifier"],
     "datacite:usesIdentifierScheme": { "@id": "datacite:doi" },
@@ -155,7 +153,6 @@ NOTE: If you have a DOI, the citation text can be [automatically generated](http
   "sameAs": "https://search.dataone.org/#view/https://www.sample-data-repository.org/dataset/472032",
   "version": "2013-11-21",
   "keywords": ["ocean acidification", "Dissolved Organic Carbon", "bacterioplankton respiration", "pCO2", "carbon dioxide", "oceans"],
-  "license": "http://creativecommons.org/licenses/by/4.0/",
   "identifier": {
     "@id": "https://doi.org/10.1575/1912/bco-dmo.665253",
     "@type": ["PropertyValue", "datacite:Identifier"],
@@ -947,7 +944,9 @@ Link a Dataset to its license to document legal constraints by adding a [schema:
 }
 </pre>
 
-While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses are an exception in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is acceptable.  Here's an example using the traditional CC URI for the license.
+SPDX URIs for each license can be found by finding the appropriate license in the [SPDX license list](https://spdx.org/licenses/), and then remove the final `.html` extension from the filename.  For example, in the table one can find the license page for Apache at the URI `https://spdx.org/licenses/Apache-2.0.html`, which can be converted into the associated linked data URI by removing the `.html`, leaving us with `https://spdx.org/licenses/Apache-2.0`. Alternatively, one can find the license file in the [structured data listings](https://github.com/spdx/license-list-data/tree/master/rdfturtle) and copy the URL from the associated file. For example, the URL for the Apache-2.0 license is listed in the file at https://github.com/spdx/license-list-data/blob/master/rdfturtle/Apache-2.0.turtle.
+
+While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses and a few others are exceptions in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is helpful in recognizing the license.  In this case, we recommend that the SPDX URI still be used as described above, and the other URI also be provided as well in a list. Here's an example using the traditional Creative Commons URI along with the SPDX URI.
 <pre>
 {
   "@context": {
@@ -956,10 +955,25 @@ While many licenses are ambiguous about the license URI for the license, the Cre
   "@id": "http://www.sample-data-repository.org/dataset/123",
   "@type": "Dataset",
   "name": "Removal of organic carbon by natural bacterioplankton communities as a function of pCO2 from laboratory experiments between 2012 and 2016",
-  <strong>"license": "https://creativecommons.org/publicdomain/zero/1.0"</strong>
+  <strong>"license": [ "http://spdx.org/licenses/CC0-1.0", "https://creativecommons.org/publicdomain/zero/1.0"]</strong>
   ...
 }
 </pre>
+
+The following table contains the SPDX URIs for some of the most common licenses.  Others can be looked up at the SPDX site as described above.
+
+|License          |  SPDX URI                                  |
+|-----------------|--------------------------------------------|
+|Apache-2.0       | https://spdx.org/licenses/Apache-2.0       |
+|BSD-3-Clause     | https://spdx.org/licenses/BSD-3-Clause     |
+|CC-BY-3.0        | https://spdx.org/licenses/CC-BY-3.0        |
+|CC-BY-4.0        | https://spdx.org/licenses/CC-BY-4.0        |
+|CC-BY-SA-4.0     | https://spdx.org/licenses/CC-BY-SA-4.0     |
+|CC0-1.0          | https://spdx.org/licenses/CC0-1.0          |
+|GPL-3.0-only     | https://spdx.org/licenses/GPL-3.0-only     |
+|GPL-3.0-or-later | https://spdx.org/licenses/GPL-3.0-or-later |
+|MIT              | https://spdx.org/licenses/MIT              |
+|MIT-0            | https://spdx.org/licenses/MIT-0            |
 
 Back to [top](#top)
 


### PR DESCRIPTION
This PR is to modify the Dataset.md guide to add a new section `License` in which we recommend people use SPDX license URIs to unambiguously specify the license for data and metadata use, as described in issue #47. The PR also includes an Architecture Decision Record describing the proposal.