### PR TITLE
Update Dataset.md for variableMeasured

### DIFF
--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -195,7 +195,8 @@ In it's most basic form, the variable as a [schema:PropertyValue](https://schema
 }
 </pre>
 <a id="variables_external-vocab-example"></a>
-A fully-fleshed out example that uses a vocabulary to describe the variable can be published as:
+If a URI is available that identifies the variable, it should be included as the 
+[PropertyID](https://schema.org/propertyID):
 
 <pre>
 {
@@ -209,8 +210,9 @@ A fully-fleshed out example that uses a vocabulary to describe the variable can 
   ...
   "variableMeasured": [
     {
-      <strong>"@type": ["PropertyValue", "gsn-quantity:latitude"],</strong>
+      "@type": "PropertyValue",
       "name": "latitude",
+      <strong>"propertyID":"gsn-quantity:latitude"</strong>,
       "url": "https://www.sample-data-repository.org/dataset-parameter/665787",
       "description": "Latitude where water samples were collected; north is positive.",
       "unitText": "decimal degrees",


### PR DESCRIPTION
re #27, #24, https://github.com/ESIPFed/science-on-schema.org/blob/master/guides/Dataset.md#variables

This revision moves the variable Identifier from the @type on in the sdo:variableMeasured value to sdo:propertyID in the sdo:PropertyValue object, and updates the text preceding the example.  The @type property is intended to assign a type to the sdo element, i.e. what is the semantics of the sdo element, and what properties are expected in the element content. In this case the sdo:variableMeasured value is an sdo:PropertyValue. The variable described by the sdo:PropertyValue is gsn-quantity:latitude, that's not the type of the sdo:variableMeasured value. 