### PR TITLE
Feature 135 json list examples guidance

### DIFF
--- a/examples/dataset/full.jsonld
+++ b/examples/dataset/full.jsonld
@@ -29,20 +29,22 @@
     "biota",
     "oceans"
   ],
-  "creator": [
-    {
-      "@type": "Person",
-      "@id": "http://lod.example-data-repository.org/id/person/51159",
-      "name": "Dr Langdon Quetin",
-      "url": "https://www.example-data-repository.org/person/51159"
-    },
-    {
-      "@type": "Person",
-      "@id": "http://lod.example-data-repository.org/id/person/51160",
-      "name": "Dr Robin Ross",
-      "url": "https://www.example-data-repository.org/person/51160"
-    }
-  ],
+  "creator": {
+    "@list": [
+      {
+        "@type": "Person",
+        "@id": "http://lod.example-data-repository.org/id/person/51159",
+        "name": "Dr Langdon Quetin",
+        "url": "https://www.example-data-repository.org/person/51159"
+      },
+      {
+        "@type": "Person",
+        "@id": "http://lod.example-data-repository.org/id/person/51160",
+        "name": "Dr Robin Ross",
+        "url": "https://www.example-data-repository.org/person/51160"
+      }
+    ]
+  },
   "citation": "Quetin, L., Ross, R. (2010) Larval krill studies - fluorescence and clearance from ARSV Laurence M. Gould LMG0106, LMG0205 in the Southern Ocean from 2001-2002 (SOGLOBEC project). Example Data Repository. Version 1. doi:10.1234/1234567890 [access date]",
   "version": "1",
   "license": "https://creativecommons.org/licenses/by/4.0/",

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -766,7 +766,47 @@ Back to [top](#top)
 
 ### Roles of People
 
-People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields creator and contributor, but using any of these fields is acceptable. Becuase there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
+People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields creator and contributor, but using any of these fields is acceptable.
+
+NOTE: Becuase JSON-LD doesn't preserve the order of its collection values, for more see [Getting Started - JSON-LD Lists](GETTING-STARTED.md#json-ld-list), we can preserve the order of people roles by applying the `@list` JSON-LD keyword. Given the following `creator` JSON-LD block,:
+	
+```
+{
+  ...
+  "creator:[
+    {
+	"@type": "Person",
+	"name": "Creator #1"
+    },
+    {
+	"@type": "Person",
+	"name": "Creator #2"
+    }
+  ]
+}
+```
+	
+The order of these creators can be preserved by the using the `@list` JSON-LD keyword:
+	
+```
+{
+  ...
+  "creator:{
+    "@list": [
+      {
+	"@type": "Person",
+	"name": "Creator #1"
+      },
+      {
+	"@type": "Person",
+	"name": "Creator #2"
+      }
+    ]
+  }
+}
+```
+	
+Becuase there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
 
 ![People Roles](/assets/diagrams/dataset/dataset_people-roles.svg "Dataset - People Roles")
 

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -768,7 +768,7 @@ Back to [top](#top)
 
 People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields creator and contributor, but using any of these fields is acceptable.
 
-NOTE: Becuase JSON-LD doesn't preserve the order of its collection values, for more see [Getting Started - JSON-LD Lists](GETTING-STARTED.md#json-ld-list), we can preserve the order of people roles by applying the `@list` JSON-LD keyword. Given the following `creator` JSON-LD block,:
+NOTE: Because JSON-LD doesn't preserve the order of its collection values, for more see [Getting Started - JSON-LD Lists](GETTING-STARTED.md#json-ld-list), we can preserve the order of people roles by applying the `@list` JSON-LD keyword. Given the following `creator` JSON-LD block,:
 	
 ```
 {
@@ -806,7 +806,7 @@ The order of these creators can be preserved by the using the `@list` JSON-LD ke
 }
 ```
 	
-Becuase there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
+Because there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
 
 ![People Roles](/assets/diagrams/dataset/dataset_people-roles.svg "Dataset - People Roles")
 


### PR DESCRIPTION
- [x] Adds use of `@list` to full example.
- [x] Omits `@list` example in the minimal JSON-LD example file becuase it's not required for all Datasets.
- [x] Adds a block of text and code example to the Dataset guide displaying use of `@list` for the `creator` property and references the explanation of JSON-LD unordered lists in the GETTING-STARTED document.