### PR TITLE
Removed text elements from temporalCoverage examples and descripton edits

### DIFF
--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -615,7 +615,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     },
     "@type": "Dataset",
         "description": "Eruptive activity at Mt. St. Helens, Washington, March 1980 - January 1981",
-<strong>        "temporalCoverage": ["1980-03-27T19:36:00/1981-01-03T00:00:00Z",
+<strong>        "temporalCoverage": [
             {
                 "@type": "time:ProperInterval",
                 "time:hasBeginning": {
@@ -630,7 +630,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 }</strong>
 </pre>
 
-2. The dataset's temporalCoverage is described using Instant, inTimePosition, hasTRS, and numericPosition elements for a single geological date/age without uncertainties from [OWL Time](http://www.w3.org/2006/time).  Use a decimal value with appropriate timescale temporal reference system (TRS) and date/age unit abbreviation. Also provide a text form of the temporalCoverage (here "760 ka"). The human readable description can be found in the description field: "Eruption of Bishop Tuff, about 760,000 years ago". 
+2. The dataset's temporalCoverage is described using Instant, inTimePosition, hasTRS, and numericPosition elements for a single geological date/age without uncertainties from [OWL Time](http://www.w3.org/2006/time).  Use a decimal value with appropriate timescale temporal reference system (TRS) and date/age unit abbreviation. The human readable description can be found in the description field: "Eruption of Bishop Tuff, about 760,000 years ago". 
 
    *Example*:
 
@@ -644,7 +644,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     {
     "@type": "Dataset",
     "description": "Eruption of Bishop Tuff, about 760,000 years ago",
-<strong>    "temporalCoverage": ["760 ka",
+<strong>    "temporalCoverage": [
         {
             "@type": "time:Instant",
             "time:inTimePosition": {
@@ -666,7 +666,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 }
 </pre>
 
-3. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, numericPosition from [OWL Time](http://www.w3.org/2006/time) with a geological date/age with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the uncertainty value and specify at what sigma. Also provide a text form of the temporalCoverage (here "4.404 +/-+/- 0.008 Ga"). "+/-+/-" indicates the uncertainty is given at 2-sigma. The human readable description can be found in the description field: "Very old zircons from the Jack Hills formation Australia 4.404 +- 0.008 Ga (2-sigma)". 
+3. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, numericPosition from [OWL Time](http://www.w3.org/2006/time) with a geological date/age with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the uncertainty value and specify at what sigma. The human readable description can be found in the description field: "Very old zircons from the Jack Hills formation Australia 4.404 +- 0.008 Ga (2-sigma)". 
 
    *Example*:
 
@@ -681,7 +681,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     {
     "@type": "Dataset",
     "description": "Very old zircons from the Jack Hills formation Australia 4.404 +- 0.008 Ga (2-sigma)",
-<strong>    "temporalCoverage": ["4.404 +/-+/- 0.008 Ga",
+<strong>    "temporalCoverage": [
         {
             "@type": "time:Instant",
             "time:inTimePosition": {
@@ -711,7 +711,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 }
 </pre>
 
-4. The dataset's temporalCoverage is described using the ProperInterval, hasBeginning, hasEnd, Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a geological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, uncertainty value and at what sigma. Also provide a text form of the temporalCoverage (here "17.1 +/- 0.15 to 15.7 +/- 0.14 Ma"). "+/-" indicates the uncertainty is given at 1-sigma. The human readable description can be found in the description field: "Isotopic ages determined at the bottom and top of a stratigraphic section in the Columbia River Basalts". 
+4. The dataset's temporalCoverage is described using the ProperInterval, hasBeginning, hasEnd, Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a geological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, uncertainty value and at what sigma. The human readable description can be found in the description field: "Isotopic ages determined at the bottom and top of a stratigraphic section in the Columbia River Basalts". 
 
    *Example*:
 
@@ -728,7 +728,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     {
     "@type": "Dataset",
     "description": "Isotopic ages determined at the bottom and top of a stratigraphic section in the Columbia River Basalts",
-<strong>    "temporalCoverage": ["17.1 +/- 0.15 to 15.7 +/- 0.14 Ma",
+<strong>    "temporalCoverage": [
         {
             "@type": "time:ProperInterval",
             "time:hasBeginning": {
@@ -788,7 +788,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 }
 </pre>
 
-5. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a archeological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the older and younger uncertainty values and at what sigma. Also provide a text form of the temporalCoverage (here "2640 +130 -80 BP-CAL (INTCAL20)"). The human readable description can be found in the description field: "Age of a piece of charcoal found in a burnt hut at an archeological site in Kenya carbon dated at BP Calibrated of 2640 +130 -80 (one-sigma) using the INTCAL20 carbon dating curve."
+5. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a archeological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the older and younger uncertainty values and at what sigma. The human readable description can be found in the description field: "Age of a piece of charcoal found in a burnt hut at an archeological site in Kenya carbon dated at BP Calibrated of 2640 +130 -80 (one-sigma) using the INTCAL20 carbon dating curve."
 
    *Example:*
 
@@ -804,7 +804,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     {
     "@type": "Dataset",
     "description": "Age of a piece of charcoal found in a burnt hut at an archeological site in Kenya carbon dated at BP Calibrated of 2640 +130 -80 (one-sigma) using the INTCAL20 carbon dating curve.",
-<strong>    "temporalCoverage": ["2640 +130 -80 BP-CAL (INTCAL20)",
+<strong>    "temporalCoverage": [
         {
             "@type": "time:Instant",
             "time:inTimePosition": {
@@ -838,7 +838,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 }
 </pre>
 
-6. The dataset's temporalCoverage is described using the Instant, TimePosition, inTimePosition, NominalPosition, Interval, hasBeginning, hasEnd, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time). With temporal coverage that is a named time interval from a geologic time scale, provide numeric positions of the beginning and end for interoperability. Providing the numeric values is only critical, but still recommended, if the TRS for the nominalPosition is not the [International Chronostratigraphic Chart](https://stratigraphy.org/chart).
+6. The dataset's temporalCoverage is described using the Instant, TimePosition, inTimePosition, NominalPosition, Interval, hasBeginning, hasEnd, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time). With temporal coverage that is a named time interval from a geologic time scale, provide numeric positions of the beginning and end for interoperability. Providing the numeric values is only critical, but still recommended, if the TRS for the nominalPosition is not the [International Chronostratigraphic Chart](https://stratigraphy.org/chart). In this example the temporalCoverage is described in two ways: by the named interval Bartonian and by defining a time interval using numerical beginning and end values.
 
    *Example:*
 
@@ -856,7 +856,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
     {
     "@type": "Dataset",
     "description": "Temporal position expressed with a named time ordinal era from [International Chronostratigraphic Chart](https://stratigraphy.org/chart):",
-<strong>    "temporalCoverage": ["Bartonian",
+<strong>    "temporalCoverage": [
         {
             "@type": "time:Instant",
             "time:inTimePosition": {
@@ -926,7 +926,7 @@ https://github.com/ESIPFed/science-on-schema.org/blob/master/examples/dataset/te
 	},
     "@type": "Dataset",
     "description": "Temporal position expressed with an interval bounded by named time ordinal eras from [International Chronostratigraphic Chart](https://stratigraphy.org/chart). NumericPositions not included, expect clients can lookup bounds for ISC nominal positions:",
-<strong>    "temporalCoverage": ["Triassic to Jurassic", {
+<strong>    "temporalCoverage": [{
         "@type": "time:ProperInterval",
         "time:hasBeginning": {
             "@type": "time:Instant",


### PR DESCRIPTION
Changes to the temporalCoverage.jsonld and decision doc were not propagated to the guidance doc.