### PR TITLE
Fix the 'publisher-provider' anchor link

### DIFF
--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -24,7 +24,7 @@
         - [Handling multiple locations](#handling-multiple-locations)
         - [Spatial Reference Systems](#spatial-reference-systems)
     - [Roles of People](#roles-of-people)
-    - [Publisher / Provider](#publisher-provider)
+    - [Publisher / Provider](#publisher--provider)
     - [Funding](#funding)
     - [License](#license)
     - [Checksum](#checksum)

--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -24,7 +24,7 @@
         - [Handling multiple locations](#handling-multiple-locations)
         - [Spatial Reference Systems](#spatial-reference-systems)
     - [Roles of People](#roles-of-people)
-    - [Publisher / Provider](#publisher--provider)
+    - [Publisher and Provider](#publisher-and-provider)
     - [Funding](#funding)
     - [License](#license)
     - [Checksum](#checksum)
@@ -1386,7 +1386,7 @@ Notice that since Uta Passow has already been defined in the document with `"@id
 
 Back to [top](#top)
 
-### Publisher / Provider
+### Publisher and Provider
 
 ![Publisher/Provider](/assets/diagrams/dataset/dataset_publisher-provider.svg "Dataset - Publisher/Provider")
 


### PR DESCRIPTION
This link wasn't working because the actual anchor has an extra dash in it.

I wasn't sure which branch to make this PR against - I think it'd be fine against master too, but that's not strictly how things are done around here.