### PR TITLE
Typos and whitespace

### DIFF
--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -35,7 +35,7 @@
 ## Common Properties
 
 Google has drafted a [guide to help publishers](https://developers.google.com/search/docs/data-types/dataset). The guide describes the only required fields as - name and description.
-* [name](https://schema.org/name) - A descriptive name of a dataset (e.g., “Snow depth in Northern Hemisphere”)
+* [name](https://schema.org/name) - A descriptive name of a dataset (e.g. “Snow depth in Northern Hemisphere”)
 * [description](https://schema.org/description) - A short summary describing a dataset.
 
 <pre>
@@ -55,7 +55,7 @@ The [Google guide](https://developers.google.com/search/docs/data-types/dataset)
 * [isAccessibleForFree](https://schema.org/isAccessibleForFree) - Boolean (true|false) specifying if the dataset is accessible for free.
 * [keywords](https://schema.org/keywords) - Keywords summarizing the dataset.
 * [identifier](https://schema.org/identifier) - An identifier for the dataset, such as a DOI. (text,URL, or PropertyValue).
-* [variableMeasured](https://schema.org/variableMeasured) - What does the dataset measure? (e.g., temperature, pressure)
+* [variableMeasured](https://schema.org/variableMeasured) - What does the dataset measure? (e.g. temperature, pressure)
 
 ![Basic Fields](/assets/diagrams/dataset/dataset_basic-fields.png "Dataset - Basic Fields")
 
@@ -100,7 +100,7 @@ For a dataset with the keywords of: `ocean acidification`, `Dissolved Organic Ca
 
 #### Keywords as DefinedTerm ####
 
-If you have information about a controlled vocabulary from which keywords come from,  use `schema:DefinedTerm` to descibe that kewyword. The relevant properties of a `schema:DefinedTerm` are:
+If you have information about a controlled vocabulary from which keywords come from, use `schema:DefinedTerm` to describe that keyword. The relevant properties of a `schema:DefinedTerm` are:
 
 * [name](https://schema.org/name) - The name of the keyword. (Required)
 * [inDefinedTermSet](https://schema.org/inDefinedTermSet) - The controlled vocabulary responsible for this keyword. (Required)
@@ -152,7 +152,7 @@ Adding the [schema:identifier](https://schema.org/identifier) field can be done 
 
 **We _highly recommend_ using [schema:PropertyValue](https://schema.org/PropertyValue).**
 
-**Q: Why are simple text or URLs not good enough?**  
+**Q: Why are simple text or URLs not good enough?**
 **A:** Identifiers have multiple properties that are useful when trying to find them across the web.
 
 Most identifiers have these properties:
@@ -169,8 +169,8 @@ For example, the Digital Object Identifier (DOI) for a dataset may be: doi:10.50
 - **url**: `https://doi.org/10.5066/F7VX0DMQ`
 - **prefix**: `doi`
 
-**Q: Can't we just say the scheme is a 'DOI'?**  
-**A:** Yes, but there's a better way - a URI or URL. Because the we are publishing schema.org to express the explicit values of our content, we want to explicitly identify and classify our content such that harvesters can determine when our content appears elsewhere on the web. By detecting these shared pieces of content, we form the [Web of Data](https://www.w3.org/standards/semanticweb/data).
+**Q: Can't we just say the scheme is a 'DOI'?**
+**A:** Yes, but there's a better way - a URI or URL. Because we are using schema.org to express the explicit values of our content, we want to explicitly identify and classify our content such that harvesters can determine when our content appears elsewhere on the web. By detecting these shared pieces of content, we form the [Web of Data](https://www.w3.org/standards/semanticweb/data).
 
 Because the **scheme** `Digital Object Identifier (DOI)` is described using unstructured text, we need a better way to explicitly state this value. Fortunately, [identifiers.org](https://registry.identifiers.org/registry) has registered URIs for almost 700 different identifier schemes which can be browsed at: [https://registry.identifiers.org/registry](https://registry.identifiers.org/registry).
 
@@ -184,10 +184,10 @@ Looking at the available fields from [schema:PropertyValue](https://schema.org/P
 - `schema:propertyID` is the registry.identifiers.org URI for the identifier scheme `https://registry.identifiers.org/registry/doi`,
 - `schema:url` is the resolvable url for that identifier `https://doi.org/10.5066/F7VX0DMQ`.
 
-**Q: Where should the prefix go?**  
-**A:** There is no ideal property for the prefix. But, we may include it as part of the `schema:value`.
+**Q: Where should the prefix go?**
+**A:** There is no ideal property for the prefix, but we may include it as part of the `schema:value`.
 
-**Q: Why include `doi:` as part of the value? Doesn't the URL `https://doi.org/10.5066/F7VX0DMQ` acheive the same result?**  
+**Q: Why include `doi:` as part of the value? Doesn't the URL `https://doi.org/10.5066/F7VX0DMQ` achieve the same result?**
 **A:** While the actual value of the DOI is `10.5066/F7VX0DMQ`, we felt that this representation helps schema.org publishers specify an identifier value that is familiar to the research community. For example, in most citation styles such as APA, the DOI 10.5066/F7VX0DMQ is cited as `doi:10.5066/F7VX0DMQ`. Also, there can be many proper URLs for a specific identifier:
 
 - http://doi.org/10.5066/F7VX0DMQ
@@ -198,8 +198,8 @@ Looking at the available fields from [schema:PropertyValue](https://schema.org/P
 
 For these reasons, we recommend that any identifier having a known prefix value should be included in the value succeeded by a colon to form '<prefix>:<value>', or for this DOI: `doi:10.5066/F7VX0DMQ`.
 
-**Q: How do I know if an Identifier has a known prefix?**  
-**A:** Each Identifier in the identifiers.org Registry that has a known prefix will be specified on the identifers.org registry page under the section called '**Identifier Schemes**' at the field labeled '**Prefix**'.
+**Q: How do I know if an Identifier has a known prefix?**
+**A:** Each Identifier in the identifiers.org Registry that has a known prefix will be specified on the identifiers.org registry page under the section called '**Identifier Schemes**' at the field labeled '**Prefix**'.
 
 An example of using [schema:PropertyValue](https://schema.org/PropertyValue) to describe an Identifier:
 
@@ -288,7 +288,7 @@ For more examples of using `schema:PropertyValue` for identifiers other than DOI
 ]
 </pre>
 
-While we strongly recommend using a [schema:PropertyValue](https://schema.org/PropertyValue), in it's most basic form, the `schema:identifier` as text can be published as:
+While we strongly recommend using a [schema:PropertyValue](https://schema.org/PropertyValue), in its most basic form, the `schema:identifier` as text can be published as:
 
 <pre>
 {
@@ -316,7 +316,7 @@ Or as a URL:
 }
 </pre>
 
-However, if the identifier is a persistent identifier such as a DOI, ARK, or accession number, then the best way to represent these identifiers is by using a [schema:PropertyValue](https://schema.org/PropertyValue). The PropertyValue allows for more information about the identifier to be represented such as the identifier type or scheme, the identifier's value, it's URL and more. Because of this flexibility, we recommend using PropertyValue for all identifier types.
+However, if the identifier is a persistent identifier such as a DOI, ARK, or accession number, then the best way to represent these identifiers is by using a [schema:PropertyValue](https://schema.org/PropertyValue). The PropertyValue allows for more information about the identifier to be represented such as the identifier type or scheme, the identifier's value, its URL and more. Because of this flexibility, we recommend using PropertyValue for all identifier types.
 
 [schema:Dataset](https://schema.org/Dataset) also defines a field for the [schema:citation](https://schema.org/citation) as either text or a [schema:CreativeWork](https://schema.org/CreativeWork). To provide citation text:
 
@@ -347,7 +347,7 @@ NOTE: If you have a DOI, the citation text can be [automatically generated](http
 
 #### How to reference Short DOIs
 
-[Short DOI](http://shortdoi.org/) is a redirect service offered by the International DOI Foundation that provides a shorter version of an orginial DOI. For example, the original DOI `doi:10.5066/F7VX0DMQ` has a short DOI of `doi.org/csgf`. Short DOIs are resolvable using standard DOI URLS such as `http://doi.org/fg5v`. These short DOIs are treated identically to the original DOI. If you are using the short DOI service, we recommend publishing a short DOI URL using the `schema:sameAs` property of the `schema:Dataset`:
+[Short DOI](http://shortdoi.org/) is a redirect service offered by the International DOI Foundation that provides a shorter version of an original DOI. For example, the original DOI `doi:10.5066/F7VX0DMQ` has a short DOI of `doi.org/csgf`. Short DOIs are resolvable using standard DOI URLS such as `http://doi.org/fg5v`. These short DOIs are treated identically to the original DOI. If you are using the short DOI service, we recommend publishing a short DOI URL using the `schema:sameAs` property of the `schema:Dataset`:
 
 <pre>
 {
@@ -384,13 +384,13 @@ Back to [top](#top)
 <a id="variables"></a>
 ### Variables
 
-A Dataset is a collection of data entities, each of which contains structured and unstructured values for a set of properties about that entity. For example, an hypothetical Dataset might contain three data files: 1) a data table in CSV format containing columns of data that both classify and measure the properties of a set of lakes in a region; 2) an image file containing rasterized geospatial data values for each location for properties like water temperature at multiple depths; and, 3) a text file containing responses to a survey assessing perspectives on water rights, with values for questions containing both natural language responses and responses on a Likert scale. In each of these examples, we are recording the value of attributes (aka properties) about an entity of interest (lake). In schema.org, details about these attributes can be recorded using `schema:variableMeasured`. So, while schema.org uses the term "variable" and the term "measured", it is usually conceptualized as a listing of any of the properties or attributes of an entity that are recorded, and not strictly a measured variable. Thus, we recommend using `schema:variableMeasured` to represent any recordable property of an entity that is found in the dataset. While this includes quantitatively "measured" observations (e.g., rainfaill in mm), it also includes classification values that are asserted or qualitatively assigned (e.g., "moderate velocity"), contextual attributes such as spatial locations, times, or sampling information associated with a value, and textual values such as narrative text.
+A Dataset is a collection of data entities, each of which contains structured and unstructured values for a set of properties about that entity. For example, an hypothetical Dataset might contain three data files: 1) a data table in CSV format containing columns of data that both classify and measure the properties of a set of lakes in a region; 2) an image file containing rasterized geospatial data values for each location for properties like water temperature at multiple depths; and 3) a text file containing responses to a survey assessing perspectives on water rights, with values for questions containing both natural language responses and responses on a Likert scale. In each of these examples, we are recording the value of attributes (aka properties) about an entity of interest (lake). In schema.org, details about these attributes can be recorded using `schema:variableMeasured`. So, while schema.org uses the term "variable" and the term "measured", it is usually conceptualized as a listing of any of the properties or attributes of an entity that are recorded, and not strictly a measured variable. Thus, we recommend using `schema:variableMeasured` to represent any recordable property of an entity that is found in the dataset. While this includes quantitatively "measured" observations (e.g. rainfall in mm), it also includes classification values that are asserted or qualitatively assigned (e.g. "moderate velocity"), contextual attributes such as spatial locations, times, or sampling information associated with a value, and textual values such as narrative text.
 
 Information about the variables/attributes in a dataset can enhance discovery and support evaluation of the data. This can be done using the [schema:variableMeasured](https://schema.org/variableMeasured) field. Schema.org allows the value of variableMeasured to be a simple text string, but it is strongly recommended to use the [schema:PropertyValue](https://schema.org/PropertyValue) type to describe the variable in more detail.
 
 ![Variables](/assets/diagrams/dataset/dataset_variables.svg "Dataset - Variables")
 
-This recommendation outlines several tiers of variable description. Tier 1 is the simplest, with other tiers adding recommendations for additional content (Tier 2 and 3).   See [Experimental Recommendations](), for proposed recommendations to document variables with with non-numeric or enumerated (controlled vocabulary) values, variables whose values are structured objects (e.g. json objects, arrays, gridded data), or are references to external value representations.
+This recommendation outlines several tiers of variable description. Tier 1 is the simplest, with other tiers adding recommendations for additional content (Tier 2 and 3). See [Experimental Recommendations](/guides/Experimental.md) for proposed recommendations to document variables with with non-numeric or enumerated (controlled vocabulary) values, variables whose values are structured objects (e.g. json objects, arrays, gridded data), or are references to external value representations.
 
 #### Tier 1. Simple list of variable names
 
@@ -417,7 +417,7 @@ Example:
 
 #### Tier 2: Names of variables with formal property types
 
-In Tier 2, we recommend using a `schema:PropertyValue` object to provide a [schema:propertyID](https://schema.org/propertyID) that better defines the semantics of the variable than plain text can. This `schema:propertyID` should be a URI that resolves to a web page providing a human-friendly description of the variable and, ideally, this identifier should also be resolvable to obtain an RDF representation using a documented vocabulary for machine consumption, for example a [sosa:Observation](https://www.w3.org/TR/vocab-ssn/#SOSAObservation) or [DDI represented variable](https://ddi-lifecycle-technical-guide.readthedocs.io/en/latest/Specific%20Structures/Data%20Description.html#represented-variable). Describing the variables with machine understandable vocabularies is necessary if you want your data to be interoperable with other data, i.e., to be more FAIR.  The property can be identified at any level of specificity, depending on what the data provider can determine about the interpretation of the variable. For example, one might use a propertyID for the property 'temperature', or use a more specific property like 'water temperature', 'sea surface water temperature', or 'sea surface water temperature measured with protocol X, daily average, Kelvins, xsd:decimal'. If there are choices, the most specific property identifier should be used.
+In Tier 2, we recommend using a `schema:PropertyValue` object to provide a [schema:propertyID](https://schema.org/propertyID) that better defines the semantics of the variable than plain text can. This `schema:propertyID` should be a URI that resolves to a web page providing a human-friendly description of the variable and, ideally, this identifier should also be resolvable to obtain an RDF representation using a documented vocabulary for machine consumption, for example a [sosa:Observation](https://www.w3.org/TR/vocab-ssn/#SOSAObservation) or [DDI represented variable](https://ddi-lifecycle-technical-guide.readthedocs.io/en/latest/Specific%20Structures/Data%20Description.html#represented-variable). Describing the variables with machine understandable vocabularies is necessary if you want your data to be interoperable with other data, i.e. to be more FAIR. The property can be identified at any level of specificity, depending on what the data provider can determine about the interpretation of the variable. For example, one might use a propertyID for the property 'temperature', or use a more specific property like 'water temperature', 'sea surface water temperature', or 'sea surface water temperature measured with protocol X, daily average, Kelvins, xsd:decimal'. If there are choices, the most specific property identifier should be used.
 
 Example:
 <pre>
@@ -446,11 +446,11 @@ Example:
 For variables with numeric measured values, other properties of schema:PropertyValue can add additional useful information:
 
 - [schema:unitText](https://schema.org/unitText). A string that identifies a unit of measurement that applies to all values for this variable.
-- [schema:unitCode](https://schema.org/unitCode). Value is expected to be TEXT or URL. We recommend providing an HTTP URI that identifies a unit of measure from a vocabulary accessible on the web.  The QUDT unit vocabulary provides an extensive set of registered units of measure that can be used to populate the schema:unitCode property to specify the units of measure used to report data values when that is appropriate.
+- [schema:unitCode](https://schema.org/unitCode). Value is expected to be TEXT or URL. We recommend providing an HTTP URI that identifies a unit of measure from a vocabulary accessible on the web. The QUDT unit vocabulary provides an extensive set of registered units of measure that can be used to populate the schema:unitCode property to specify the units of measure used to report data values when that is appropriate.
 - [schema:minValue](https://schema.org/minValue). If the value for the variable is numeric, this is the minimum value that occurs in the dataset. Not useful for other value types.
 - [schema:maxValue](https://schema.org/maxValue). If the value for the variable is numeric, this is the maximum value that occurs in the dataset. Not useful for other value types.
-- [schema:measurementTechnique](https://schema.org/measurementTechnique). A text description of the measurement method used to determine values for this variable. If standard measurement protocols are defined and registered, these can be identified via http URI's.
-- [schema:url](https://schema.org/url) Any schema:Thing can have a URL property, but because the value is simply a url the relationship of the linked resource can not be expressed.  Usage is optional. The recommendation is that `schema:url` should link to a web page that would be useful for a person to interpret the variable, but is not intended to be machine-actionable.
+- [schema:measurementTechnique](https://schema.org/measurementTechnique). A text description of the measurement method used to determine values for this variable. If standard measurement protocols are defined and registered, these can be identified via http URIs.
+- [schema:url](https://schema.org/url) Any schema:Thing can have a URL property, but because the value is simply a url the relationship of the linked resource can not be expressed. Usage is optional. The recommendation is that `schema:url` should link to a web page that would be useful for a person to interpret the variable, but is not intended to be machine-actionable.
 
 Example:
 <pre>
@@ -510,16 +510,16 @@ Back to [top](#top)
 
 ### Metadata
 
-While this schema.org record represents metadata about a Dataset, many providers will also have other metadata records that may be more complete or that conform to other metadata formats and vocabularies that might be useful. For example, repositories often contain detailed records in ISO TC 211 formats, [EML](https://eml.ecoinformatics.org), and other formats. Aggregators and other consumers can make use of this additional metadata if they are linked in a standardized way to the schema.org record.  We recommend that the location of the alternative forms of the metadata be provided using the [schema:subjectOf](https://schema.org/subjectOf) and [schema:about](https://schema.org/about) properties:
+While this schema.org record represents metadata about a Dataset, many providers will also have other metadata records that may be more complete or that conform to other metadata formats and vocabularies that might be useful. For example, repositories often contain detailed records in ISO TC 211 formats, [EML](https://eml.ecoinformatics.org), and other formats. Aggregators and other consumers can make use of this additional metadata if they are linked in a standardized way to the schema.org record. We recommend that the location of the alternative forms of the metadata be provided using the [schema:subjectOf](https://schema.org/subjectOf) and [schema:about](https://schema.org/about) properties:
 
-Link metadata documents to a [schema:Dataset](https://schema.org/Dataset) by using [schema:subjectOf](https://schema.org/subjectOf).
-    - Or if a schema.org snippet describes the metadata as the main resource, then link to the Dataset it describes using [schema:about](https://schema.org/about).
+- Link metadata documents to a [schema:Dataset](https://schema.org/Dataset) by using [schema:subjectOf](https://schema.org/subjectOf).
+- Or if a schema.org snippet describes the metadata as the main resource, then link to the Dataset it describes using [schema:about](https://schema.org/about).
 
 These two approaches are equivalent, and which is used depends on the subject of the schema.org record.
 
 ![Metadata](/assets/diagrams/dataset/dataset_metadata.svg "Dataset - Metadata")
 
-Once the linkage has been made, further details about the metadata can be provided. We recommend using [schema:encodingFormat](https://schema.org/encodingFormat) to indicate the metadata format/vocabulary to which the metadata record conforms.  If it conforms to multiple formats, or to a specific and general format types, multiple types can be listed.  
+Once the linkage has been made, further details about the metadata can be provided. We recommend using [schema:encodingFormat](https://schema.org/encodingFormat) to indicate the metadata format/vocabulary to which the metadata record conforms. If it conforms to multiple formats, or to a specific and general format types, multiple types can be listed.
 We use the [schema:DataDownload](https://schema.org/DataDownload) class for Metadata files so that we can use the [schema:MediaObject](https://schema.org/MediaObject) properties for describing bytesize, encoding, etc.
 
 It can be useful to aggregators and other consumers to indicate when the metadata record was last modified using `schema:dateModified`, which can be used to optimize harvesting schedules for search indices and other applications.
@@ -546,7 +546,7 @@ An example of a metadata reference to an instance of EML-formatted structured me
   }
 </pre>
 
-Alternatively, if the schema.org record is meant to describe the metadata record, one could use the inverse property `schema:about` to indicate the linkage back to the Dataset that it describes.  This should be a rare situation, as typically the schema.org record will describe the Dataset itself.
+Alternatively, if the schema.org record is meant to describe the metadata record, one could use the inverse property `schema:about` to indicate the linkage back to the Dataset that it describes. This should be a rare situation, as typically the schema.org record will describe the Dataset itself.
 
 Note that the `encodingFormat` property contains an array of formats to describe multiple formats to which the document conforms (in this example, the document is both conformant with XML and the EML metadata dialect).
 
@@ -631,19 +631,19 @@ If access to the data requires some input parameters before a download can occur
 }
 </pre>
 
-Here, we use the [schema:SearchAction](https://schema.org/SearchAction) type becuase it lets you define the query parameters and HTTP methods so that machines can build user interfaces to collect those query parmaeters and actuate a request to provide the user what they are looking for.
+Here, we use the [schema:SearchAction](https://schema.org/SearchAction) type because it lets you define the query parameters and HTTP methods so that machines can build user interfaces to collect those query parameters and actuate a request to provide the user what they are looking for.
 
 Back to [top](#top)
 
 ### Dates
 
-Scientific datasets typically have multiple associated date or time periods.  Time periods can be specified for 1) the time at which an entity or phenonomon occurred or was measured, and 2) the time periods when a dataset containing that information was created, changed, published, etc. `temporalCoverage` describes the age of the sample and the other dates describe the data created from observations or process. For example, if one took a sample 200 ft down in an ice core, `temporalCoverage` would describe the period when that layer of ice was deposited in geologic time, while other date properties (dateCreated, dateModified, datePublished, and expired) would describe the dataset that was created by measuring and analyzing that ice core sample. The temporalCoverage might also be a range of ages. For example if the dataset was from a study of the whole ice core it could have a range of ages from 300 to 6000 years before present (BP).
+Scientific datasets typically have multiple associated date or time periods. Time periods can be specified for 1) the time at which an entity or phenomenon occurred or was measured, and 2) the time periods when a dataset containing that information was created, changed, published, etc. `temporalCoverage` describes the age of the sample and the other dates describe the data created from observations or process. For example, if one took a sample 200 ft down in an ice core, `temporalCoverage` would describe the period when that layer of ice was deposited in geologic time, while other date properties (dateCreated, dateModified, datePublished, and expired) would describe the dataset that was created by measuring and analyzing that ice core sample. The temporalCoverage might also be a range of ages. For example if the dataset was from a study of the whole ice core it could have a range of ages from 300 to 6000 years before present (BP).
 
 Schema.org offers various date properties that can be used to encode this information. We recommend use of the following fields for Dates:
 
 - `schema:temporalCoverage` :: use to specify the **time period(s) that the content applies to**, i.e. the time the entity or phenomenon described in the dataset occurred. See details at [temporalCoverage](#temporal-coverage). `temporalCoverage` is usually prior to the date of data publication for observational data, and can be afterwards for models, simulations, and forecasts.
 
-- `schema:dateCreated` ::  use to specify the date the dataset was initially generated (e.g., when a sensor recorded a value, when a model was run, or when data processing was completed). This is typically fixed when the first dataset version is created.
+- `schema:dateCreated` :: use to specify the date the dataset was initially generated (e.g. when a sensor recorded a value, when a model was run, or when data processing was completed). This is typically fixed when the first dataset version is created.
 - `schema:dateModified` :: use to specify the date the dataset was most recently updated or changed.
 - `schema:datePublished` :: use to specify the date when a dataset was made available to the public through a publication process.
 - `schema:expires` :: use to specify the date when the dataset expires and is no longer useful or available. If `datePublished` is when the dataset is made available, then 'expires' brackets the time the dataset is valid or recommended for use.
@@ -651,9 +651,9 @@ Schema.org offers various date properties that can be used to encode this inform
 Back to [top](#top)
 
 ### Temporal Coverage
-Temporal coverage is defined as "the time period during which data was collected or observations were made; or a time period that an activity or collection is linked to intellectually or thematically (for example, 1997 to 1998; the 18th century)" ([ARDC RIF-CS](https://documentation.ardc.edu.au/display/DOC/Temporal+coverage)). For documentation of Earth Science, Paleobiology or Paleontology datasets, we are interested in the second case-- the time period that data are linked to thematically.
+Temporal coverage is defined as "the time period during which data was collected or observations were made; or a time period that an activity or collection is linked to intellectually or thematically (for example, 1997 to 1998; the 18th century)" ([ARDC RIF-CS](https://documentation.ardc.edu.au/display/DOC/Temporal+coverage)). For documentation of Earth Science, Paleobiology or Paleontology datasets, we are interested in the second case: the time period that data are linked to thematically.
 
-Temporal coverage is a difficult concept to cover across all the possible scenarios. Schema.org uses [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) to describe time intervals and time points, but doesn't provide capabilities for geologic time scales or dynamically generated data up to present time. We ask for your [feedback](https://github.com/earthcubearchitecture-project418/p418Vocabulary/issues) on any temporal coverages you may have that don't currently fit into schema.org. You can follow [similar issues](https://github.com/schemaorg/schemaorg/issues/242) on the schema.org GitHub issue queue. We hope that our examples of the use of [OWL Time](https://www.w3.org/TR/owl-time/) and temporal reference system ([TRS](https://vocabs.gsq.digital/object?uri=http://linked.data.gov.au/def/trs)) elements will help you describe the dates or ages of the entities in a dataset. We have also included examples that describe dataset's [time uncertainties](http://geoschemas.org/extensions/temporal.html).    
+Temporal coverage is a difficult concept to cover across all the possible scenarios. Schema.org uses [ISO 8601 time interval format](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) to describe time intervals and time points, but doesn't provide capabilities for geologic time scales or dynamically generated data up to present time. We ask for your [feedback](https://github.com/earthcubearchitecture-project418/p418Vocabulary/issues) on any temporal coverages you may have that don't currently fit into schema.org. You can follow [similar issues](https://github.com/schemaorg/schemaorg/issues/242) on the schema.org GitHub issue queue. We hope that our examples of the use of [OWL Time](https://www.w3.org/TR/owl-time/) and temporal reference system ([TRS](https://vocabs.gsq.digital/object?uri=http://linked.data.gov.au/def/trs)) elements will help you describe the dates or ages of the entities in a dataset. We have also included examples that describe dataset's [time uncertainties](http://geoschemas.org/extensions/temporal.html).
 
 ![Temporal](/assets/diagrams/dataset/dataset_temporal-coverage.svg "Dataset - Temporal")
 
@@ -696,7 +696,7 @@ Schema.org also lets you provide date ranges and other temporal coverages throug
 
 #### Geologic Time
 
-Dates or ages used for describing geological, archeological, and paleontological samples range from the very simple to highly complex. A lava rock age could be simply described as 1.23 million years. Other ages are more descriptive. Some other examples are: a zircon crystal with an age of 456.4 +/- 1.4  billion years (Ga) at a standard error of 2-sigma, a core with rocks from the Triassic to the Jurassic, a carbon date of a bone with non-symmetrical uncertainties of 3242 (+160 -40) B.C. We make use of the OWL time ([Cox and Little](https://w3c.github.io/sdw/time/)) descriptive tags (elements), the Queensland Department of Natural Resources, Mines and Energy Temporal Reference Systems ([TRS](https://vocabs.gsq.digital/object?uri=http://linked.data.gov.au/def/trs)), and geoschemas' [properties](https://geoschemas.org/extensions/temporal.html#properties) to describe ages and age ranges in detail. These methods could also be used to describe the temporal coverage for other disciplines as well. 
+Dates or ages used for describing geological, archeological, and paleontological samples range from the very simple to highly complex. A lava rock age could be simply described as 1.23 million years. Other ages are more descriptive. Some other examples are: a zircon crystal with an age of 456.4 +/- 1.4 billion years (Ga) at a standard error of 2-sigma, a core with rocks from the Triassic to the Jurassic, a carbon date of a bone with non-symmetrical uncertainties of 3242 (+160 -40) B.C. We make use of the OWL time ([Cox and Little](https://w3c.github.io/sdw/time/)) descriptive tags (elements), the Queensland Department of Natural Resources, Mines and Energy Temporal Reference Systems ([TRS](https://vocabs.gsq.digital/object?uri=http://linked.data.gov.au/def/trs)), and geoschemas' [properties](https://geoschemas.org/extensions/temporal.html#properties) to describe ages and age ranges in detail. These methods could also be used to describe the temporal coverage for other disciplines as well.
 
 There are two main types of geologic time: Proper Intervals and Instants. They are diagrammed below and used in the examples that follow.
 
@@ -710,7 +710,7 @@ There are two main types of geologic time: Proper Intervals and Instants. They a
 
 These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/examples/dataset/temporalCoverage.jsonld)
 
-1. The dataset's temporalCoverage is described using ProperInterval, hasBeginning, and hasEnd elements from [OWL Time](http://www.w3.org/2006/time). The human readable description can be found in the description field: "Eruptive activity at Mt. St. Helens, Washington, March 1980 - January 1981". 
+1. The dataset's temporalCoverage is described using ProperInterval, hasBeginning, and hasEnd elements from [OWL Time](http://www.w3.org/2006/time). The human readable description can be found in the description field: "Eruptive activity at Mt. St. Helens, Washington, March 1980 - January 1981".
 
   *Example*:
 
@@ -737,7 +737,7 @@ These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/ex
 }</strong>
 </pre>
 
-2. The dataset's temporalCoverage is described using Instant, inTimePosition, hasTRS, and numericPosition elements for a single geological date/age without uncertainties from [OWL Time](http://www.w3.org/2006/time).  Use a decimal value with appropriate timescale temporal reference system (TRS) and date/age unit abbreviation. The human readable description can be found in the description field: "Eruption of Bishop Tuff, about 760,000 years ago". 
+2. The dataset's temporalCoverage is described using Instant, inTimePosition, hasTRS, and numericPosition elements for a single geological date/age without uncertainties from [OWL Time](http://www.w3.org/2006/time). Use a decimal value with appropriate timescale temporal reference system (TRS) and date/age unit abbreviation. The human readable description can be found in the description field: "Eruption of Bishop Tuff, about 760,000 years ago".
 
    *Example*:
 
@@ -772,7 +772,7 @@ These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/ex
 }
 </pre>
 
-3. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, numericPosition from [OWL Time](http://www.w3.org/2006/time) with a geological date/age with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the uncertainty value and specify at what sigma. The human readable description can be found in the description field: "Very old zircons from the Jack Hills formation Australia 4.404 +- 0.008 Ga (2-sigma)". 
+3. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, numericPosition from [OWL Time](http://www.w3.org/2006/time) with a geological date/age with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the uncertainty value and specify at what sigma. The human readable description can be found in the description field: "Very old zircons from the Jack Hills formation Australia 4.404 +- 0.008 Ga (2-sigma)".
 
    *Example*:
 
@@ -816,7 +816,7 @@ These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/ex
 }
 </pre>
 
-4. The dataset's temporalCoverage is described using the ProperInterval, hasBeginning, hasEnd, Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a geological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, uncertainty value and at what sigma. The human readable description can be found in the description field: "Isotopic ages determined at the bottom and top of a stratigraphic section in the Columbia River Basalts". 
+4. The dataset's temporalCoverage is described using the ProperInterval, hasBeginning, hasEnd, Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a geological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, uncertainty value and at what sigma. The human readable description can be found in the description field: "Isotopic ages determined at the bottom and top of a stratigraphic section in the Columbia River Basalts".
 
    *Example*:
 
@@ -892,7 +892,7 @@ These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/ex
 }
 </pre>
 
-5. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with a archeological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system(TRS), date/age unit abbreviation, the older and younger uncertainty values and at what sigma. The human readable description can be found in the description field: "Age of a piece of charcoal found in a burnt hut at an archeological site in Kenya carbon dated at BP Calibrated of 2640 +130 -80 (one-sigma) using the INTCAL20 carbon dating curve."
+5. The dataset's temporalCoverage is described using the Instant, inTimePosition, TimePosition, and hasTRS elements from [OWL Time](http://www.w3.org/2006/time) with an archeological date/age range with uncertainties. Use a decimal value with appropriate timescale temporal reference system (TRS), date/age unit abbreviation, the older and younger uncertainty values and at what sigma. The human readable description can be found in the description field: "Age of a piece of charcoal found in a burnt hut at an archeological site in Kenya carbon dated at BP Calibrated of 2640 +130 -80 (one-sigma) using the INTCAL20 carbon dating curve."
 
    *Example:*
 
@@ -1013,7 +1013,7 @@ These examples can be found in one JSON-LD file at [temporalCoverage.jsonld](/ex
 }
 </pre>
 
-7. Temporal intervals with nominal temporal position that have identifiers. When possible, use temporal intervals defined by the [International Chronostratigraphic Chart](https://stratigraphy.org/chart), access via [ARDC vocabulary service](https://vocabs.ardc.edu.au/viewById/196), or via [GeoSciML vocabularies landing page](http://geosciml.org/resource/). If temporal intervals with identifies from other schemes are available, they can be included in a separate time:ProperInterval or time:Instant element.  If intervals are not from the ICS chart it is recommended to provide an interval with beginning and end numeric positions for better interoperability.
+7. Temporal intervals with nominal temporal position that have identifiers. When possible, use temporal intervals defined by the [International Chronostratigraphic Chart](https://stratigraphy.org/chart), access via [ARDC vocabulary service](https://vocabs.ardc.edu.au/viewById/196), or via [GeoSciML vocabularies landing page](http://geosciml.org/resource/). If temporal intervals with identifiers from other schemes are available, they can be included in a separate time:ProperInterval or time:Instant element. If intervals are not from the ICS chart it is recommended to provide an interval with beginning and end numeric positions for better interoperability.
 
    *Example:*
 
@@ -1056,9 +1056,9 @@ Back to [top](#top)
 
 ![Spatial](/assets/diagrams/dataset/dataset_spatial-coverage.svg "Dataset - Spatial")
 
-Used to document the location on Earth that is the focus of the  dataset content, using  [schema:Place](https://schema.org/Place). Recommended practice is to use the [schema:geo](https://schema.org/geo) property with either a [schema:GeoCoordinates](https://schema.org/GeoCoordinates) object to specify a point location, or a [schema:GeoShape](https://schema.org/GeoShape) object to specify a line or area coverage extent. Coordinates describing these extents are expressed as latitude longitude tuples (in that order) using decimal degrees.
+Used to document the location on Earth that is the focus of the dataset content, using [schema:Place](https://schema.org/Place). Recommended practice is to use the [schema:geo](https://schema.org/geo) property with either a [schema:GeoCoordinates](https://schema.org/GeoCoordinates) object to specify a point location, or a [schema:GeoShape](https://schema.org/GeoShape) object to specify a line or area coverage extent. Coordinates describing these extents are expressed as latitude longitude tuples (in that order) using decimal degrees.
 
-Schema.org documentation does not specify a convention for the coordinate reference system, our recommended practice is to use [WGS84](EPSG:3857) for at least one spatial coverage description if applicable. Spatial coverage location using other coordinate systems can be included, see recommendation for specifying coordinate reference systems, [below](#spatial_reference-system).  
+Schema.org documentation does not specify a convention for the coordinate reference system, our recommended practice is to use [WGS84](EPSG:3857) for at least one spatial coverage description if applicable. Spatial coverage location using other coordinate systems can be included, see recommendation for specifying coordinate reference systems, [below](#spatial_reference-system).
 
 #### Use GeoCoordinates for Point locations
 
@@ -1088,7 +1088,7 @@ Point locations are recommended for data that is associated with specific sample
 
 #### Use GeoShape for all other location types
 
-<a id="spatial_shape"></a>A [schema:GeoShape](https://schema.org/GeoShape) can describe spatial coverage as a line (e.g. a ship track), a bounding box, a polygon, or a circle. The geometry is described with a set of latitude/longitude pairs. The spatial definitions were added to schema.org early in its [development](https://github.com/schemaorg/schemaorg/issues/8#issuecomment-97667478) based on the [GeoRSS specification](http://docs.opengeospatial.org/cs/17-002r1/17-002r1.html#21). The documentation for [schema:GeoShape](https://schema.org/GeoShape) states "Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points." At least for bounding boxes (see the discussion below), it appears that the Google Dataset Search parsing of the coordinate strings depends on whether a comma or space is used to delimit the coordinates in an individual tuple.  
+<a id="spatial_shape"></a>A [schema:GeoShape](https://schema.org/GeoShape) can describe spatial coverage as a line (e.g. a ship track), a bounding box, a polygon, or a circle. The geometry is described with a set of latitude/longitude pairs. The spatial definitions were added to schema.org early in its [development](https://github.com/schemaorg/schemaorg/issues/8#issuecomment-97667478) based on the [GeoRSS specification](http://docs.opengeospatial.org/cs/17-002r1/17-002r1.html#21). The documentation for [schema:GeoShape](https://schema.org/GeoShape) states "Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points." At least for bounding boxes (see the discussion below), it appears that the Google Dataset Search parsing of the coordinate strings depends on whether a comma or space is used to delimit the coordinates in an individual tuple.
 
 Be aware that some client applications might only index or display bounding box extents.
 
@@ -1125,21 +1125,21 @@ A polygon provides the most precise approach to delineating the spatial extent o
 
 ##### <a id="geoshape-box">Bounding Boxes</a>
 
-A GeoShape box defines an area on the surface of the earth defined by point locations of the southwest corner and northeast corner of the rectangle in latitude-longitude coordinates. Point locations are tuples of {latitude  east-longitude} (y x). The schema.org [GeoShape](https://schema.org/GeoShape) documentation states "*Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points*." Since the box is a list of points, a space should be used to separate the latitude and longitude values. The two corner coordinate points are separated by a space. 'East longitude' means positive longitude values are east of the prime (Greenwich) meridian.  A box where 'lower-left' (southwest) corner is 39.3280/120.1633 and 'upper-right' (northeast) corner is 40.445/123.7878 would be encoded thus:
+A GeoShape box defines an area on the surface of the earth defined by point locations of the southwest corner and northeast corner of the rectangle in latitude-longitude coordinates. Point locations are tuples of {latitude east-longitude} (y x). The schema.org [GeoShape](https://schema.org/GeoShape) documentation states "*Either whitespace or commas can be used to separate latitude and longitude; whitespace should be used when writing a list of several such points*." Since the box is a list of points, a space should be used to separate the latitude and longitude values. The two corner coordinate points are separated by a space. 'East longitude' means positive longitude values are east of the prime (Greenwich) meridian. A box where 'lower-left' (southwest) corner is 39.3280/120.1633 and 'upper-right' (northeast) corner is 40.445/123.7878 would be encoded thus:
 <pre>
   <strong>"box": "39.3280 120.1633 40.445 123.7878"</strong>
 </pre>
 
-NOTE-- see [discussion in GitHub issue 101](https://github.com/ESIPFed/science-on-schema.org/issues/101#issuecomment-720808142) on what works with Google Dataset search to display spatial locatation in their search results.
+NOTE-- see [discussion in GitHub issue 101](https://github.com/ESIPFed/science-on-schema.org/issues/101#issuecomment-720808142) on what works with Google Dataset search to display spatial location in their search results.
 
-East longitude values can be reported 0 <= X <= 360 or -180 <= X <= 180. Some applications will fail under one or the other of these conventions. Recommendation is to use -180 <= X <= 180, consistent with the [WKT specification](https://docs.opengeospatial.org/is/18-010r7/18-010r7.html#33).  Following this recommendation, bounding boxes that cross the antimeridian at ±180° longitude, the West longitude value will be numerically greater than the East longitude value. For example, to describe Fiji the box might be
+East longitude values can be reported 0 <= X <= 360 or -180 <= X <= 180. Some applications will fail under one or the other of these conventions. Recommendation is to use -180 <= X <= 180, consistent with the [WKT specification](https://docs.opengeospatial.org/is/18-010r7/18-010r7.html#33). Following this recommendation, bounding boxes that cross the antimeridian at ±180° longitude, the West longitude value will be numerically greater than the East longitude value. For example, to describe Fiji the box might be
 <pre>
   <strong>"box": "-19 176 -15 -178"</strong>
 </pre>
 
 NOTES: Some spatial data processors will not correctly interpret the bounding coordinates across the antimeridian even if they follow the recommended southwest, northeast corner convention, resulting in boxes that span the circumference of the Earth, excluding the actual area of interest. For applications operating with data in the vicinity of longitude 180, testing is strongly recommended to determine if it works for bounding boxes crossing the antimeridian (+/- 180); an alternative is to define two bounding boxes, one on each side of 180.
 
-For bounding boxes that include the north or south pole, schema:box will not work. Recommended practice is to use a schema:polygon to describe spatial location extents that include the poles.  
+For bounding boxes that include the north or south pole, schema:box will not work. Recommended practice is to use a schema:polygon to describe spatial location extents that include the poles.
 
 #### Handling multiple locations
 
@@ -1168,13 +1168,13 @@ If you have multiple geometries, you can publish those by making the [schema:geo
 }
 </pre>
 
-Be aware that some client application might not index or display multiple geometries.
+Be aware that some client applications might not index or display multiple geometries.
 
 #### Spatial Reference Systems
 
 A Spatial Reference System (SRS) or Coordinate Reference System (CRS) is the method for defining the [frame of reference for geospatial location representation](https://developers.arcgis.com/documentation/core-concepts/spatial-references/). Schema.org currently has no defined property for specifying a Spatial Reference System; the assumption is that coordinates are WGS84 decimal degrees.
 
-In the mean time, to represent an SRS in schema.org, we recommend using the [schema:additionalProperty](https://schema.org/additionalProperty) property to specify an object of type [schema:PropertyValue](https://schema.org/PropertyValue), with a [schema:propertyID](https://schema.org/propertyID) of
+In the meantime, to represent an SRS in schema.org, we recommend using the [schema:additionalProperty](https://schema.org/additionalProperty) property to specify an object of type [schema:PropertyValue](https://schema.org/PropertyValue), with a [schema:propertyID](https://schema.org/propertyID) of
 [http://dbpedia.org/resource/Spatial_reference_system](http://dbpedia.org/resource/Spatial_reference_system) to identify the property as a spatial reference system, and the schema:PropertyValue/schema:value is a URI (IRI) that identifies a specific SRS. Some commonly used values are:
 
 | Spatial Reference System | IRI                                          |
@@ -1220,9 +1220,9 @@ Back to [top](#top)
 
 People can be linked to datasets using three fields: author, creator, and contributor. Since  [schema:contributor](https://schema.org/contributor) is defined as a secondary author, and [schema:Creator](https://schema.org/creator) is defined as being synonymous with the [schema:author](https://schema.org/author) field, we recommend using the more expressive fields creator and contributor, but using any of these fields is acceptable.
 
-NOTE: JSON-LD doesn't preserve the order of its collection values, so if you need to preserve the order of people's names (e.g., for a citation) you can do so by applying the `@list` JSON-LD keyword (for more information about this see [Getting Started - JSON-LD Lists](GETTING-STARTED.md#json-ld-list)). 
+NOTE: JSON-LD doesn't preserve the order of its collection values, so if you need to preserve the order of people's names (e.g. for a citation) you can do so by applying the `@list` JSON-LD keyword (for more information about this see [Getting Started - JSON-LD Lists](GETTING-STARTED.md#json-ld-list)).
 
-Given the following `creator` JSON-LD block,:
+Given the following `creator` JSON-LD block:
 
 ```
 {
@@ -1451,7 +1451,7 @@ Data providers should include funding information in their Dataset descriptions 
 
 ![NSF ROR Entry](/assets/images/ror.png "Dataset - Funder Identifiers")
 
-Linking a Dataset to the grants and awards that fund it can be acheived by adding a [schema:MonetaryGrant](https://schema.org/MonetaryGrant) through the `schema:funding` property. 
+Linking a Dataset to the grants and awards that fund it can be achieved by adding a [schema:MonetaryGrant](https://schema.org/MonetaryGrant) through the `schema:funding` property.
 
 <pre>
 {
@@ -1481,7 +1481,7 @@ Linking a Dataset to the grants and awards that fund it can be acheived by addin
       "@type": "MonetaryGrant",
       "@id": "https://akareport.aka.fi/ibi_apps/WFServlet?IBIF_ex=x_hakkuvaus2&HAKNRO1=316349&UILANG=en&TULOSTE=HTML",
       "identifier": "316349",
-      "name": "Where does water go when snow melts? New spatio-temporal resolution in stable water isotopes measurements to inform cold climate hydrological modelling",        
+      "name": "Where does water go when snow melts? New spatio-temporal resolution in stable water isotopes measurements to inform cold climate hydrological modelling",
       "url": "https://akareport.aka.fi/ibi_apps/WFServlet?IBIF_ex=x_hakkuvaus2&HAKNRO1=316349&UILANG=en&TULOSTE=HTML",
       "funder": {
         "@id": "http://dx.doi.org/10.13039/501100002341",
@@ -1504,7 +1504,7 @@ Back to [top](#top)
 
 ### License
 
-Link a Dataset to its license to document legal constraints by adding a [schema:license](https://schema.org/license) property. The [guide](https://developers.google.com/search/docs/data-types/dataset) recommends providing a URL that unambiguously identifies a specific version of the license used, but for many licenses it is hard to determine what that URL should be. Thus, we recommend that the license URL be drawn from the [SPDX license list](https://spdx.org/licenses/), which provides a curated list of licenses and their properties that is well maintained. For each SPDX entry, SPDX provides a canonical URL for the license (e.g., `http://spdx.org/licenses/CC0-1.0`), a unique `licenseId` (e.g., `CC0-1.0`), and other metadata about the license. Here's an example using the SPDX license URI for the Creative Commons CC-0 license:
+Link a Dataset to its license to document legal constraints by adding a [schema:license](https://schema.org/license) property. The [guide](https://developers.google.com/search/docs/data-types/dataset) recommends providing a URL that unambiguously identifies a specific version of the license used, but for many licenses it is hard to determine what that URL should be. Thus, we recommend that the license URL be drawn from the [SPDX license list](https://spdx.org/licenses/), which provides a curated list of licenses and their properties that is well maintained. For each SPDX entry, SPDX provides a canonical URL for the license (e.g. `http://spdx.org/licenses/CC0-1.0`), a unique `licenseId` (e.g. `CC0-1.0`), and other metadata about the license. Here's an example using the SPDX license URI for the Creative Commons CC-0 license:
 
 <pre>
 {
@@ -1517,9 +1517,9 @@ Link a Dataset to its license to document legal constraints by adding a [schema:
 }
 </pre>
 
-SPDX URIs for each license can be found by finding the appropriate license in the [SPDX license list](https://spdx.org/licenses/), and then remove the final `.html` extension from the filename.  For example, in the table one can find the license page for Apache at the URI `https://spdx.org/licenses/Apache-2.0.html`, which can be converted into the associated linked data URI by removing the `.html`, leaving us with `https://spdx.org/licenses/Apache-2.0`. Alternatively, one can find the license file in the [structured data listings](https://github.com/spdx/license-list-data/tree/master/rdfturtle) and copy the URL from the associated file. For example, the URL for the Apache-2.0 license is listed in the file at https://github.com/spdx/license-list-data/blob/master/rdfturtle/Apache-2.0.turtle.
+SPDX URIs for each license can be found by finding the appropriate license in the [SPDX license list](https://spdx.org/licenses/), and then remove the final `.html` extension from the filename. For example, in the table one can find the license page for Apache at the URI `https://spdx.org/licenses/Apache-2.0.html`, which can be converted into the associated linked data URI by removing the `.html`, leaving us with `https://spdx.org/licenses/Apache-2.0`. Alternatively, one can find the license file in the [structured data listings](https://github.com/spdx/license-list-data/tree/master/rdfturtle) and copy the URL from the associated file. For example, the URL for the Apache-2.0 license is listed in the file at https://github.com/spdx/license-list-data/blob/master/rdfturtle/Apache-2.0.turtle.
 
-While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses and a few others are exceptions in that they provide extremely consistent URIs for each license, and these are in widespread use.  So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is helpful in recognizing the license.  In this case, we recommend that the SPDX URI still be used as described above, and the other URI also be provided as well in a list. Here's an example using the traditional Creative Commons URI along with the SPDX URI.
+While many licenses are ambiguous about the license URI for the license, the Creative Commons licenses and a few others are exceptions in that they provide extremely consistent URIs for each license, and these are in widespread use. So, while we recommend using the SPDX URI, we recognize that some sites may want to use the CC license URIs directly, which is helpful in recognizing the license. In this case, we recommend that the SPDX URI still be used as described above, and the other URI also be provided as well in a list. Here's an example using the traditional Creative Commons URI along with the SPDX URI.
 <pre>
 {
   "@context": "https://schema.org/",
@@ -1531,9 +1531,9 @@ While many licenses are ambiguous about the license URI for the license, the Cre
 }
 </pre>
 
-The following table contains the SPDX URIs for some of the most common licenses.  Others can be looked up at the SPDX site as described above.
+The following table contains the SPDX URIs for some of the most common licenses. Others can be looked up at the SPDX site as described above.
 
-|License          |  SPDX URI                                  |
+|License          | SPDX URI                                  |
 |-----------------|--------------------------------------------|
 |Apache-2.0       | https://spdx.org/licenses/Apache-2.0       |
 |BSD-3-Clause     | https://spdx.org/licenses/BSD-3-Clause     |
@@ -1607,7 +1607,7 @@ We recommend providing provenance information about data processing workflows, d
 
 ![Prov_versions](/assets/diagrams/dataset/dataset_prov_revision.svg "Dataset - Revisions")
 
-Link a Dataset to a prior version that it replaces by adding a [`prov:wasRevisionOf`](https://www.w3.org/TR/prov-o/#wasRevisionOf) property. This indicates that the current `schema:Dataset` replaces or obsoletes the source Dataset indicated.  The value of the `prov:wasRevisionOf` should be the canonical IRI for the identifier for the original dataset, preferably to a persistently resolvable IRI such as as a DOI, but other persistent identifiers for the dataset can be used.
+Link a Dataset to a prior version that it replaces by adding a [`prov:wasRevisionOf`](https://www.w3.org/TR/prov-o/#wasRevisionOf) property. This indicates that the current `schema:Dataset` replaces or obsoletes the source Dataset indicated. The value of the `prov:wasRevisionOf` should be the canonical IRI for the identifier for the original dataset, preferably to a persistently resolvable IRI such as as a DOI, but other persistent identifiers for the dataset can be used.
 
 <pre>
 {
@@ -1628,7 +1628,7 @@ Link a Dataset to a prior version that it replaces by adding a [`prov:wasRevisio
 
 A derived Dataset is one in which the values in the data are somehow related or created from the values in one or more source datasets. For example, raw voltage values from a sensor might be recorded in a raw data file, which is then processed through calibration functions to produce a derived dataset with values in scientific units. Other examples of derived data include data that has been error corrected, gap-filled, or integrated with other sources.
 
-To indicate that a Dataset has been derived from a source Dataset, use the [`prov:wasDerivedFrom`](https://www.w3.org/TR/prov-o/#wasDerivedFrom) property. This indicates that the current `schema:Dataset` was created in whole or in part from content in the source Dataset, and therefore does not represent an independent set of measurements.  The value of the `prov:wasDerivedFrom` should be the canonical IRI for the identifer for the source dataset, preferably to a persistently resolvable IRI such as as a DOI, but other persistent identifiers for the dataset can be used. In addition, if a persistent identifier for a digital object within a Dataset is available, the `prov:wasDerivedFrom` may also be used to indicate that that digital object was derived from that particular source object, rather than the overall Dataset. This allows one to be more specific about the exact relationship between the source and derived data objects.
+To indicate that a Dataset has been derived from a source Dataset, use the [`prov:wasDerivedFrom`](https://www.w3.org/TR/prov-o/#wasDerivedFrom) property. This indicates that the current `schema:Dataset` was created in whole or in part from content in the source Dataset, and therefore does not represent an independent set of measurements. The value of the `prov:wasDerivedFrom` should be the canonical IRI for the identifier for the source dataset, preferably to a persistently resolvable IRI such as a DOI, but other persistent identifiers for the dataset can be used. In addition, if a persistent identifier for a digital object within a Dataset is available, the `prov:wasDerivedFrom` may also be used to indicate that that digital object was derived from that particular source object, rather than the overall Dataset. This allows one to be more specific about the exact relationship between the source and derived data objects.
 
 In addition to `prov:wasDerivedFrom`, schema.org provides the [`schema:isBasedOn`](https://schema.org/isBasedOn) property, which should be considered to be an equivalent property to `prov:wasDerivedFrom`. For compatibility with schema.org, we recommend that producers use `schema:isBasedOn` in addition to or instead of `prov:wasDerivedFrom` to indicate derivation relationships.
 

--- a/guides/GETTING-STARTED.md
+++ b/guides/GETTING-STARTED.md
@@ -41,7 +41,7 @@ To provide a place for the scientific data community to work out how best to imp
 1. To be **pragmatic** with our use of schema.org and external vocabulary adoption.
 2. To **consider schema.org classes and properties first** before considering external vocabularies.
 3. Use **[JSON-LD](https://json-ld.org/)** in our guidance documents for simplicity and terseness as compared to *[Microdata](https://www.w3.org/TR/microdata/)* and *[RDFa](https://rdfa.info/)*. For more, see [Why JSON-LD?](/CONVENTIONS.md#why-jsonld) from the [Conventions](/CONVENTIONS.md) document.
-4. Presently, the [Google Rich Results Tool](https://search.google.com/test/rich-results) enforces use of [schema.org](https://schema.org/) classes and properties by displaying an error whenever external vocabularies are used. schema.org proposes linking to external vocabularies usuing the [schema:additionalType](https://schema.org/additionalType) property. While this property is defined as a sub property of [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), it's data type is a literal. However, using the [Schema.org Validator](https://validator.schema.org/) allows for the use of external vocabularies. We encourage the use of JSON-LD ```'@type'``` for typing classes to external vocabularies. For more, see [Typing to External Vocabularies](/CONVENTIONS.md#external-vocab-typing) from the [Conventions](/CONVENTIONS.md) document.
+4. Presently, the [Google Rich Results Tool](https://search.google.com/test/rich-results) enforces use of [schema.org](https://schema.org/) classes and properties by displaying an error whenever external vocabularies are used. schema.org proposes linking to external vocabularies using the [schema:additionalType](https://schema.org/additionalType) property. While this property is defined as a sub property of [rdf:type](http://www.w3.org/1999/02/22-rdf-syntax-ns#type), its data type is a literal. However, using the [Schema.org Validator](https://validator.schema.org/) allows for the use of external vocabularies. We encourage the use of JSON-LD ```'@type'``` for typing classes to external vocabularies. For more, see [Typing to External Vocabularies](/CONVENTIONS.md#external-vocab-typing) from the [Conventions](/CONVENTIONS.md) document.
 5. See [Governance](/GOVERNANCE.md) for how we will govern the project.
 6. See [Conventions](/CONVENTIONS.md) for guidance on creating/editing guidance documents.
 
@@ -53,18 +53,18 @@ To provide a place for the scientific data community to work out how best to imp
 
   JSON-LD is valid JSON, so standard developer tools that support JSON can be used. For some specific JSON-LD and schema.org help though, there are some other resources.
 
-  ##### JSON-LD resources  https://json-ld.org
-  Generating the JSON-LD is best done via libraries like those you can find at https://json-ld.org.  
-  There are libraries for; Javascript, Python, PHP, Ruby, Java, C# and Go.  While JSON-LD is just
+  ##### JSON-LD resources https://json-ld.org
+  Generating the JSON-LD is best done via libraries like those you can find at https://json-ld.org.
+  There are libraries for; Javascript, Python, PHP, Ruby, Java, C# and Go. While JSON-LD is just
   JSON and can be generated many ways, these libraries
-  can generate valid JSON-LD spec output.   
+  can generate valid JSON-LD spec output.
 
   ##### JSON-LD playground https://json-ld.org/playground/
   The playground is hosted at the very useful [JSON-LD web site](https://json-ld.org) site. You
-  can explore examples of JSON-LD and view how they convert to RDF, flatten, etc.   Note, that JSON-LD
-  is not associated with schema.org.  It can be used for much more and so most examples here don't
-  use schema.org and this site will NOT look to see if you are using schema.org types and properties
-  correctly.  Only that your JSON-LD is well formed.  
+  can explore examples of JSON-LD and view how they convert to RDF, flatten, etc. Note that JSON-LD
+  is not associated with schema.org. It can be used for much more and so most examples at the JSON-LD
+  website don't use schema.org and the site will NOT look to see if you are using schema.org types
+  and properties correctly; it will only check that your JSON-LD is well-formed.
 
 3. We assume that you've heard about [schema.org](https://schema.org/) and have already decided that it's useful to you.
 4. We assume that you have a general understanding of what may describe a scientific dataset.
@@ -73,10 +73,10 @@ Let's go!
 
 <a id="introduction"></a>
 ## Introduction ##
-There is an emerging practice to leverage structured metadata to aid in the discovery of web based resources.  Much of this
-work is taking place in the context (no pun intended) of schema.org.  This approach has extended to the resource type Dataset.
+There is an emerging practice to leverage structured metadata to aid in the discovery of web-based resources. Much of this
+work is taking place in the context (no pun intended) of schema.org. This approach has extended to the resource type Dataset.
 This page will present approaches, tools and references that will aid in the understanding and development of schema.org in
-JSON-LD and its connection to external vocabularies.  For a more thorough presentation on this visit the Google AI Blog entry
+JSON-LD and its connection to external vocabularies. For a more thorough presentation on this, visit the Google AI Blog entry
 of January 24 2017 at https://ai.googleblog.com/2017/01/facilitating-discovery-of-public.html .
 
 <a id="using-schemaorg"></a>
@@ -84,7 +84,7 @@ of January 24 2017 at https://ai.googleblog.com/2017/01/facilitating-discovery-o
 
 <a id="using-schemaorg_adding-jsonld-webpages"></a>
 ### Modifying web pages to include schema.org as JSON-LD ###
-JSON-LD should be incorporated into the landing page html inside the `<head></head>` as a `<script>` element with a type of `application/ld+json`.  
+JSON-LD should be incorporated into the landing page html inside the `<head></head>` as a `<script>` element with a type of `application/ld+json`.
 
 ```
 <html>
@@ -108,14 +108,14 @@ JSON-LD should be incorporated into the landing page html inside the `<head></he
 ### Specifying the `context`
 
 The `context` in a JSON-LD document defines the namespaces used in the document and their mappings to URIs when they
-are referenced using prefix notation. The JSON-LD 1.1 specification 
+are referenced using prefix notation. The JSON-LD 1.1 specification
 [provides many rules](https://www.w3.org/TR/json-ld11-api/#remote-document-and-context-retrieval) that impact how the context is
 loaded and how it is retrieved, but ultimately the goal is to define a context map with the namespace mappings for each
 vocabulary used in the document. For the schema.org vocabulary specifically, the official namespace is `http://schema.org/`
 (note this is not an `https` URI), but the context file for schema.org can be retrieved from the `https` web location at
 `https://schema.org` by following the JSON-LD processing rules. For providers, this translates to a few simple recommendations.
 
-1. We recommend retrieving the context file from it's `https` location using the following syntax:
+1. We recommend retrieving the context file from its `https` location using the following syntax:
 
 ```
 {
@@ -126,7 +126,7 @@ vocabulary used in the document. For the schema.org vocabulary specifically, the
 }
 ```
 
-Using that approach, the schema.org namespace will be set to `http` URIs. For example the `Dataset` type will be expanded to
+Using this approach, the schema.org namespace will be set to `http` URIs. For example the `Dataset` type will be expanded to
 `http://schema.org/Dataset`.
 
 2. Should you need to define additional namespaces in your context, it can be done by expanding the context using a JSON array as follows:
@@ -156,7 +156,7 @@ namespace for the `prov` vocabulary to the context. Now, terms from the PROV nam
 accepting `https://schema.org/` as an equivalent namespace URI for all terms, processors should treat schema.org terms in the http and https
 URI spaces as equivalent, but providers might find it safer to continue to use `http://schema.org/` as the official namespace for now. This
 particularly applies when defining a default vocabulary for un-prefixed terms, in which case we recommend using `"@vocab": "http://schema.org/"`
-if this is necessary. That said, most user's should not have need to define `@vocab` in typical usage.
+if this is necessary. That said, most users should not have need to define `@vocab` in typical usage.
 
 <a id="sitemaps"></a>
 ### Provide a Sitemap.xml file
@@ -179,7 +179,7 @@ Many harvesters and aggregators depend on the existence of a `sitemap.xml` file 
 
 Note the `<lastmod>` field, which indicates the last date on which the page was modified and is formatted as a [W3C DateTime](https://www.w3.org/TR/NOTE-datetime) and may vary in precision. Most harvesters will use that date along with the HTTP `Last-modified` header to determine if a page has changed since the last time that a harvest was attempted. Keeping accurate `lastmod` values can massively improve the efficiency of indexing your catalog, as only the few items that have changed will need to be indexed.
 
-**Location:** The sitemap.xml file can be located anywhere on your site that is above the path in the hierachy in which your pages are listed. Typically, the sitemap.xml is places at the root of the site, but other locations can be used as well. A great way to indicate to harvesters where your sitemap is located would be to include it in your `robots.txt` file at the root of your web site, which is bascially an instruction manual for harvesters. For example, you might have a robots.txt file with the following contents:
+**Location:** The sitemap.xml file can be located anywhere on your site that is above the path in the hierarchy in which your pages are listed. Typically, the sitemap.xml is placed at the root of the site, but other locations can be used as well. A great way to indicate to harvesters where your sitemap is located would be to include it in your `robots.txt` file, which is basically an instruction manual for harvesters, at the root of your web site. For example, you might have a robots.txt file with the following contents:
 
 <pre>
 User-agent: *
@@ -199,10 +199,10 @@ For each schema.org type, such as Person or Event, there are fields that let you
 <p align="center">
   <strong>Figure 1. schema.org field data types</strong><br/>
   <img src="/assets/schemaorg-datatypes.png">
-  <em>The expected data type for each field appears in the middle column. The left column is the name of the field, the middle column is the data type, and the right column is the field's description.</em>
+  <em>The expected data type for each field appears in the middle column. The left column is the name of the field, the middle column is the data type, and the right column is the description of the field.</em>
 </p>
 
-Every data type is either a *resource* or a *literal*. Resources refer to other schema.org types. For example a Dataset type has a field called author of which the data type can be either a Person or an Organization. Because Person and Organization are other schema.org "types" who have their own fields, they are called resources. In JSON-LD, you specify resources by using curly brackets ```{}```:
+Every data type is either a *resource* or a *literal*. Resources refer to other schema.org types. For example, a Dataset type has a field called 'author' of which the data type can be either a 'Person' or an 'Organization'. Because 'Person' and 'Organization' are other schema.org "types" with their own fields, they are called resources. In JSON-LD, you specify resources by using curly brackets ```{}```:
 
 <pre>
 {
@@ -217,9 +217,9 @@ Every data type is either a *resource* or a *literal*. Resources refer to other 
 
 In the JSON-LD above, the 'author' is a resource of type 'Person'. Fields that simply have a value are called literal data types. For examples, the 'Person' type above has a 'name' of "Jane Goodall" - a literal text value.
 
-Schema.org defines six literal, or primitive,  data types: [Text](https://schema.org/Text), [Number](https://schema.org/Number), [Boolean](https://schema.org/Boolean), [Date](https://schema.org/Date), [DateTime](https://schema.org/DateTime), and [Time](https://schema.org/Time). [Text](https://schema.org/Text) has two special variations: [URL](https://schema.org/URL) and how to specify when text is actually [HTML](#data-type_HTML).  
+Schema.org defines six literal, or primitive, data types: [Text](https://schema.org/Text), [Number](https://schema.org/Number), [Boolean](https://schema.org/Boolean), [Date](https://schema.org/Date), [DateTime](https://schema.org/DateTime), and [Time](https://schema.org/Time). [Text](https://schema.org/Text) has two special variations: [URL](https://schema.org/URL) and how to specify when text is actually [HTML](#data-type_HTML).
 
-When using schema.org, literal data types are not not specified using curly brackets ```{}``` as these are resrved for specifying 'objects' or 'resources' such as other schema.org types like ```Person```, ```Organization```, etc. First, let's see how to use a primitive data type by using fields of [CreativeWork](https://schema.org/CreativeWork), the superclass for [Dataset](https://schema.org/Dataset).
+When using schema.org, literal data types are not specified using curly brackets ```{}``` as these are reserved for specifying 'objects' or 'resources' such as other schema.org types like ```Person```, ```Organization```, etc. First, let's see how to use a primitive data type by using fields of [CreativeWork](https://schema.org/CreativeWork), the superclass for [Dataset](https://schema.org/Dataset).
 
 <a id="data-types_Text"></a>
 #### Text ####
@@ -248,7 +248,7 @@ Let's say we want to specify the version number of our manifest using the [versi
 
 <a id="data-types_URL"></a>
 #### URL ####
-Now, let's specify the URL of our manifest using the [url](https://schema.org/url) field of CreativeWork, an inheritied field from [Thing](https://schema.org/Thing). This fields expects a valid URL represented as Text:
+Now, let's specify the URL of our manifest using the [url](https://schema.org/url) field of CreativeWork, an inherited field from [Thing](https://schema.org/Thing). This fields expects a valid URL represented as Text:
 
 <pre>
 {
@@ -262,7 +262,7 @@ Now, let's specify the URL of our manifest using the [url](https://schema.org/ur
 
 <a id="data-types_Boolean"></a>
 #### Boolean ####
-Using the Boolean value, we can speficy that our manifest is accessible for free using the field [isAccessibleForFree](https://schema.org/isAccessibleForFree) by using the text ```true``` or ```false``` and omitting the quotes:
+Using the Boolean value, we can specify that our manifest is accessible for free using the field [isAccessibleForFree](https://schema.org/isAccessibleForFree) by using the text ```true``` or ```false``` and omitting the quotes:
 
 <pre>
 {
@@ -295,7 +295,7 @@ To specify the [datePublished](https://schema.org/datePublished), which allows e
 <a id="data-types_DateTime"></a>
 #### DateTime ####
 
-To specify the [dateModified](https://schema.org/dateModified) as a DateTime, as a Date, we must follow the [ISO 8601  format for combining date and time representations](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) using the form ```[-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] ```:
+To specify the [dateModified](https://schema.org/dateModified) as a DateTime, as a Date, we must follow the [ISO 8601 format for combining date and time representations](https://en.wikipedia.org/wiki/ISO_8601#Combined_date_and_time_representations) using the form ```[-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm] ```:
 
 <pre>
 {
@@ -378,7 +378,7 @@ All schema.org resources should make use of the ```@type``` property which 'clas
 }
 </pre>
 
-Even though the above resource has a name of 'My Dataset' harvesters are unaware that your *intent* was to classify it as a Dataset. Un-typed resources are not valid schema.org resources, and so they require the ```@type``` property:
+Even though the above resource has a name of 'My Dataset', harvesters are unaware that your *intent* was to classify it as a Dataset. Un-typed resources are not valid schema.org resources, and so they require the ```@type``` property:
 
 <pre>
 {
@@ -388,7 +388,7 @@ Even though the above resource has a name of 'My Dataset' harvesters are unaware
 }
 </pre>
 
-In some cases, it useful to multi-type a resource. One example of this may be a data repository. A data repositotry is typically functioning as noth an 'Organization' that employs people and has an address, but it also functions as a 'Service' to its user community. To multi-type a resource, we use JSON arrays:
+In some cases, it useful to multi-type a resource. One example of this may be a data repository. A data repository is typically functioning as both an 'Organization' that employs people and has an address, but also as a 'Service' to its user community. To assign multiple types to a resource, we use JSON arrays:
 
 <pre>
 {
@@ -436,7 +436,7 @@ may have a [`dateModified`](https://schema.org/dateModified) property to indicat
 the CreativeWork was most recently modified or when the item's entry was modified within a DataFeed."
 This property should be provided with any instance of `schema.org/Dataset` or any other `schema.org`
 entity published in a landing page or though other mechanisms. The JSON spec does not include a
-built-in type for date time values, however the general consensus and a sensible practices is to
+built-in type for date time values, but the general consensus and a sensible practice is to
 represent a date time value as a time zone aware ISO 8601 formatted string. For example:
 
 ```json
@@ -482,7 +482,7 @@ desireable, and should be provided where possible. For example:
 <a id="json-ld-list"></a>
 ### Ordering items with JSON-LD `@list`
 
-Unlike plain JSON, collections in JSON-LD are unordered [[1](https://json-ld/json-ld.org#12), [2](https://www.w3.org/TR/json-ld/#lists)]. In cases where ordering of items needs to be preserved, we can use the `@list` keyword to specify that order should be preserved for a collection.  Ordered lists would be important, for example, when a list of authors or creators should be ordered as intended when rendering a view of the metadata, or when a list of bounding box coordinates in an array need to come in a particular order.
+Unlike plain JSON, collections in JSON-LD are unordered [[1](https://json-ld/json-ld.org#12), [2](https://www.w3.org/TR/json-ld/#lists)]. In cases where ordering of items needs to be preserved, we can use the `@list` keyword to specify that order should be preserved for a collection. Ordered lists would be important, for example, when a list of authors or creators should be ordered as intended when rendering a view of the metadata, or when a list of bounding box coordinates in an array need to come in a particular order.
 
 In the following example, the list of `creator` items is not ordered, and so client tools could return the creator names in any order, and different tools may return them in different orders. This would be problematic for building a citation, for example.
 
@@ -565,4 +565,4 @@ Example 3. Ordering of a list of creators is preserved anywhere such a list appe
 }
 ```
 
-With this technique, ordering can be set once in the context using `@list`, and then order will be preserved anytime that concept is used in the document.
+With this technique, ordering can be set once in the context using `@list`, and then order will be preserved any time that concept is used in the document.


### PR DESCRIPTION
A few edits that I noticed whilst reading through the docs.

Miscellaneous typos, errant apostrophes, and excess whitespace removed.