### PR TITLE
Fix link to schema:Role blog post in Dataset.md by pointing to archive.org

### DIFF
--- a/guides/Dataset.md
+++ b/guides/Dataset.md
@@ -1260,7 +1260,7 @@ The order of these creators can be preserved by the using the `@list` JSON-LD ke
 }
 ```
 
-Because there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
+Because there are more things that can be said about how and when a person contributed to a Dataset, we use the [schema:Role](https://schema.org/Role). You'll notice that the schema.org documentation does not state that the Role type is an expected data type of author, creator and contributor, but that is addressed in this [blog post introducing Role into schema.org](https://web.archive.org/web/20191231224838/http://blog.schema.org/2014/06/introducing-role.html). *Thanks to [Stephen Richard](https://github.com/smrgeoinfo) for this contribution*
 
 ![People Roles](/assets/diagrams/dataset/dataset_people-roles.svg "Dataset - People Roles")
 


### PR DESCRIPTION

Updated the link to the blog post about schema:Role to point to the archived version, since that page 404s now